### PR TITLE
Update continue-as-new test configs for step durability defaults

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -204,6 +204,7 @@ type (
 // DefaultWorkflowConfig is used when Interpreter.DefaultWorkflowConfig is nil.
 var DefaultWorkflowConfig = &dexpb.FlowConfig{
 	ContinueAsNewThreshold: ptr.Any(int32(100)),
+	StepDurability:         ptr.Any(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
 }
 
 // NewConfig returns a new decoded Config struct.

--- a/server/integ/any_command_close_test.go
+++ b/server/integ/any_command_close_test.go
@@ -51,7 +51,7 @@ func TestAnyCommandCloseFlowTemporalContinueAsNew(t *testing.T) {
 		doTestAnyCommandCloseFlow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -75,7 +75,7 @@ func TestAnyCommandCloseFlowCadenceContinueAsNew(t *testing.T) {
 		doTestAnyCommandCloseFlow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/any_command_combination_test.go
+++ b/server/integ/any_command_combination_test.go
@@ -52,7 +52,7 @@ func TestAnyCommandCombinationFlowTemporalContinueAsNew(t *testing.T) {
 		doTestAnyCommandCombinationFlow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -76,7 +76,7 @@ func TestAnyCommandCombinationFlowCadenceContinueAsNew(t *testing.T) {
 		doTestAnyCommandCombinationFlow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/any_timer_signal_test.go
+++ b/server/integ/any_timer_signal_test.go
@@ -81,7 +81,7 @@ func TestAnyTimerSignalFlowTemporalContinueAsNew(t *testing.T) {
 		doTestAnyTimerSignalFlow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -92,7 +92,7 @@ func TestGreedyAnyTimerSignalFlowTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestAnyTimerSignalFlow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestAnyTimerSignalFlow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -105,7 +105,7 @@ func TestAnyTimerSignalFlowCadenceContinueAsNew(t *testing.T) {
 		doTestAnyTimerSignalFlow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -116,7 +116,7 @@ func TestGreedyAnyTimerSignalFlowCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestAnyTimerSignalFlow(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestAnyTimerSignalFlow(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/basic_test.go
+++ b/server/integ/basic_test.go
@@ -49,9 +49,7 @@ func TestBasicFlowTemporal(t *testing.T) {
 			doTestBasicFlow(
 				t,
 				service.BackendTypeTemporal,
-				minimumContinueAsNewConfig(
-					dexpb.StepDurability_STEP_DURABILITY_ASYNC,
-				),
+				minimumContinueAsNewAsyncDurabilityConfig(),
 			)
 		})
 		t.Run(fmt.Sprintf("active-step-search-disabled-%d", i), func(t *testing.T) {
@@ -76,9 +74,7 @@ func TestBasicFlowCadence(t *testing.T) {
 			doTestBasicFlow(
 				t,
 				service.BackendTypeCadence,
-				minimumContinueAsNewConfig(
-					dexpb.StepDurability_STEP_DURABILITY_ASYNC,
-				),
+				minimumContinueAsNewAsyncDurabilityConfig(),
 			)
 		})
 		t.Run(fmt.Sprintf("active-step-search-disabled-%d", i), func(t *testing.T) {

--- a/server/integ/conditional_close_test.go
+++ b/server/integ/conditional_close_test.go
@@ -62,7 +62,7 @@ func TestConditionalForceCompleteOnInternalChannelEmptyWorkflowTemporalContinueA
 		doTestConditionalForceCompleteOnInternalChannelEmptyWorkflow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -76,7 +76,7 @@ func TestConditionalForceCompleteOnInternalChannelEmptyWorkflowCadenceContinueAs
 		doTestConditionalForceCompleteOnInternalChannelEmptyWorkflow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/create_test.go
+++ b/server/integ/create_test.go
@@ -61,7 +61,7 @@ func TestCreateFlowTemporalContinueAsNew(t *testing.T) {
 		doTestCreateWithoutStartingStep(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -75,7 +75,7 @@ func TestCreateFlowCadenceContinueAsNew(t *testing.T) {
 		doTestCreateWithoutStartingStep(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/deadend_test.go
+++ b/server/integ/deadend_test.go
@@ -60,7 +60,7 @@ func TestDeadEndFlowTemporalContinueAsNew(t *testing.T) {
 		doTestDeadEndFlow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -74,7 +74,7 @@ func TestDeadEndFlowCadenceContinueAsNew(t *testing.T) {
 		doTestDeadEndFlow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/greedy_timer_test.go
+++ b/server/integ/greedy_timer_test.go
@@ -60,7 +60,7 @@ func TestGreedyTimerFlowBaseTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestGreedyTimerFlowCustomConfig(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestGreedyTimerFlowCustomConfig(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -70,7 +70,7 @@ func TestGreedyTimerFlowBaseCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestGreedyTimerFlowCustomConfig(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestGreedyTimerFlowCustomConfig(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/headers_test.go
+++ b/server/integ/headers_test.go
@@ -45,7 +45,7 @@ func TestHeadersFlowTemporal(t *testing.T) {
 		doTestFlowWithHeaders(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 
@@ -68,7 +68,7 @@ func TestHeadersFlowCadence(t *testing.T) {
 		doTestFlowWithHeaders(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/internalchannel_test.go
+++ b/server/integ/internalchannel_test.go
@@ -44,7 +44,7 @@ func TestInterStateWorkflowTemporal(t *testing.T) {
 		doTestInterStateWorkflow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -60,7 +60,7 @@ func TestInterStateWorkflowCadence(t *testing.T) {
 		doTestInterStateWorkflow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/large_data_attributes_test.go
+++ b/server/integ/large_data_attributes_test.go
@@ -40,7 +40,7 @@ func TestLargeDataAttributesTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestLargeQueryAttributes(t, minimumContinueAsNewConfigV0())
+		doTestLargeQueryAttributes(t, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/locking_test.go
+++ b/server/integ/locking_test.go
@@ -55,7 +55,7 @@ func TestLockingWorkflowTemporalContinueAsNew(t *testing.T) {
 		doTestLockingWorkflow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -79,7 +79,7 @@ func TestLockingWorkflowCadenceContinueAsNew(t *testing.T) {
 		doTestLockingWorkflow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/parallel_test.go
+++ b/server/integ/parallel_test.go
@@ -44,7 +44,7 @@ func TestParallelFlowTemporal(t *testing.T) {
 		doTestParallelFlow(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -60,7 +60,7 @@ func TestParallelFlowCadence(t *testing.T) {
 		doTestParallelFlow(
 			t,
 			service.BackendTypeCadence,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/persistence_test.go
+++ b/server/integ/persistence_test.go
@@ -64,7 +64,7 @@ func TestPersistenceWorkflowTemporalContinueAsNew(t *testing.T) {
 			t,
 			service.BackendTypeTemporal,
 			false,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -79,7 +79,7 @@ func TestPersistenceWorkflowTemporalContinueAsNewWithEncryption(t *testing.T) {
 			t,
 			service.BackendTypeTemporal,
 			true,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}
@@ -104,7 +104,7 @@ func TestPersistenceWorkflowCadenceContinueAsNew(t *testing.T) {
 			t,
 			service.BackendTypeCadence,
 			false,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+			minimumContinueAsNewSyncDurabilityConfig(),
 		)
 		smallWaitForFastTest()
 	}

--- a/server/integ/rpc_test.go
+++ b/server/integ/rpc_test.go
@@ -51,7 +51,7 @@ func TestRpcWorkflowTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestRpcWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestRpcWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -81,7 +81,7 @@ func TestRpcWorkflowTemporalContinueAsNewWithMemo(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestRpcWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestRpcWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -91,7 +91,7 @@ func TestRpcWorkflowTemporalContinueAsNewWithMemoAndEncryption(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestRpcWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestRpcWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -111,7 +111,7 @@ func TestRpcWorkflowCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestRpcWorkflow(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestRpcWorkflow(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/runtime.go
+++ b/server/integ/runtime.go
@@ -376,15 +376,28 @@ func smallWaitForFastTest() {
 	time.Sleep(duration)
 }
 
-func minimumContinueAsNewConfig(durability dexpb.StepDurability) *dexpb.FlowConfig {
+func minimumContinueAsNewAsyncDurabilityConfig() *dexpb.FlowConfig {
+	config := asyncDurabilityConfig()
+	config.ContinueAsNewThreshold = ptr.Any(int32(1))
+	return config
+}
+
+func minimumContinueAsNewSyncDurabilityConfig() *dexpb.FlowConfig {
+	config := syncDurabilityConfig()
+	config.ContinueAsNewThreshold = ptr.Any(int32(1))
+	return config
+}
+
+func asyncDurabilityConfig() *dexpb.FlowConfig {
 	return &dexpb.FlowConfig{
-		ContinueAsNewThreshold: ptr.Any(int32(1)),
-		StepDurability:         ptr.Any(durability),
+		StepDurability: ptr.Any(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
 	}
 }
 
-func minimumContinueAsNewConfigV0() *dexpb.FlowConfig {
-	return minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_SYNC)
+func syncDurabilityConfig() *dexpb.FlowConfig {
+	return &dexpb.FlowConfig{
+		StepDurability: ptr.Any(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+	}
 }
 
 func encodedObjectValue(encoding string, payload []byte) *dexpb.Value {

--- a/server/integ/signal_test.go
+++ b/server/integ/signal_test.go
@@ -53,7 +53,7 @@ func TestSignalWorkflowTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestSignalWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestSignalWorkflow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -73,7 +73,7 @@ func TestSignalWorkflowCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestSignalWorkflow(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestSignalWorkflow(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -177,7 +177,7 @@ func doTestSignalWorkflow(
 	assertions.Equal(
 		map[string]*dexpb.ChannelInfo{
 			signal.UnhandledSignalName: {Size: 10},
-			signal.InternalChannelName:  {Size: 10},
+			signal.InternalChannelName: {Size: 10},
 		},
 		infos,
 	)

--- a/server/integ/skip_start_test.go
+++ b/server/integ/skip_start_test.go
@@ -48,7 +48,7 @@ func TestSkipStartFlowTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestSkipStartFlow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestSkipStartFlow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -68,7 +68,7 @@ func TestSkipStartFlowCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestSkipStartFlow(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestSkipStartFlow(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/timer_test.go
+++ b/server/integ/timer_test.go
@@ -61,7 +61,7 @@ func TestTimerFlowTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestTimerFlow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestTimerFlow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -71,7 +71,7 @@ func TestTimerFlowCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestTimerFlow(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestTimerFlow(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -102,7 +102,7 @@ func TestGreedyTimerFlowTemporalContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestTimerFlow(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestTimerFlow(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -112,7 +112,7 @@ func TestGreedyTimerFlowCadenceContinueAsNew(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestTimerFlow(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestTimerFlow(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/wait_for_attribute_test.go
+++ b/server/integ/wait_for_attribute_test.go
@@ -356,7 +356,7 @@ func doTestWaitForAttributeAcrossContinueAsNew(t *testing.T) {
 		ctx,
 		flowClient,
 		workerTarget,
-		minimumContinueAsNewConfigV0(),
+		minimumContinueAsNewSyncDurabilityConfig(),
 	)
 	expectedValue := stringValue("wait-for-attribute-can")
 

--- a/server/integ/wait_for_state_completion_test.go
+++ b/server/integ/wait_for_state_completion_test.go
@@ -208,7 +208,7 @@ func doTestWaitForStateCompletionAcrossContinueAsNew(t *testing.T) {
 		StartStepType:      wait_for_state_completion.State1,
 		StepInput:          stringValue(strconv.FormatInt(time.Now().Unix(), 10)),
 		FlowStartOptions: &dexpb.FlowStartOptions{
-			FlowConfigOverride: minimumContinueAsNewConfigV0(),
+			FlowConfigOverride: minimumContinueAsNewSyncDurabilityConfig(),
 		},
 	})
 	require.NoError(t, err)

--- a/server/integ/wf_force_fail_test.go
+++ b/server/integ/wf_force_fail_test.go
@@ -39,7 +39,7 @@ func TestFlowForceFailTemporal(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestFlowForceFail(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestFlowForceFail(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestFlowForceFail(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -51,7 +51,7 @@ func TestFlowForceFailCadence(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestFlowForceFail(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestFlowForceFail(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestFlowForceFail(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/wf_state_api_fail_test.go
+++ b/server/integ/wf_state_api_fail_test.go
@@ -37,12 +37,20 @@ func TestStateApiFailTemporal(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestStateApiFail(t, service.BackendTypeTemporal, nil)
+		doTestStateApiFail(t, service.BackendTypeTemporal, nil, dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED)
 		smallWaitForFastTest()
 		doTestStateApiFail(
 			t,
 			service.BackendTypeTemporal,
-			minimumContinueAsNewConfig(dexpb.StepDurability_STEP_DURABILITY_ASYNC),
+			minimumContinueAsNewAsyncDurabilityConfig(),
+			dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED,
+		)
+		smallWaitForFastTest()
+		doTestStateApiFail(
+			t,
+			service.BackendTypeTemporal,
+			asyncDurabilityConfig(),
+			dexpb.StepDurability_STEP_DURABILITY_SYNC,
 		)
 		smallWaitForFastTest()
 	}
@@ -53,9 +61,14 @@ func TestStateApiFailCadence(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestStateApiFail(t, service.BackendTypeCadence, nil)
+		doTestStateApiFail(t, service.BackendTypeCadence, nil, dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED)
 		smallWaitForFastTest()
-		doTestStateApiFail(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestStateApiFail(
+			t,
+			service.BackendTypeCadence,
+			minimumContinueAsNewSyncDurabilityConfig(),
+			dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED,
+		)
 		smallWaitForFastTest()
 	}
 }
@@ -64,6 +77,7 @@ func doTestStateApiFail(
 	t *testing.T,
 	backendType service.BackendType,
 	flowConfig *dexpb.FlowConfig,
+	waitForDurabilityOverride dexpb.StepDurability,
 ) {
 	workerHandler := wf_state_api_fail.NewHandler()
 	workerTarget := startWorker(t, workerHandler)
@@ -83,6 +97,7 @@ func doTestStateApiFail(
 		WorkerTarget:       workerTarget,
 		StartStepType:      wf_state_api_fail.Step1,
 		StepOptions: &dexpb.StepOptions{
+			WaitForDurabilityOverride: waitForDurabilityOverride,
 			WaitForRetryPolicy: &dexpb.RetryPolicy{
 				TotalDurationSeconds: 1,
 			},
@@ -104,7 +119,8 @@ func doTestStateApiFail(
 	history := workerHandler.GetTestResult().InvokeHistory
 	expectedWaitFor := int64(1)
 	if flowConfig != nil &&
-		flowConfig.GetStepDurability() == dexpb.StepDurability_STEP_DURABILITY_ASYNC {
+		flowConfig.GetStepDurability() == dexpb.StepDurability_STEP_DURABILITY_ASYNC &&
+		waitForDurabilityOverride != dexpb.StepDurability_STEP_DURABILITY_SYNC {
 		expectedWaitFor = 4
 	}
 	require.Equal(t, map[string]int64{

--- a/server/integ/wf_state_api_timeout_test.go
+++ b/server/integ/wf_state_api_timeout_test.go
@@ -39,7 +39,7 @@ func TestStateApiTimeoutTemporal(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestStateApiTimeout(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestStateApiTimeout(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestStateApiTimeout(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -51,7 +51,7 @@ func TestStateApiTimeoutCadence(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestStateApiTimeout(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestStateApiTimeout(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestStateApiTimeout(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/wf_state_execute_api_fail_and_proceed_test.go
+++ b/server/integ/wf_state_execute_api_fail_and_proceed_test.go
@@ -37,9 +37,26 @@ func TestStateExecuteApiFailAndProceedTemporal(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestStateExecuteApiFailAndProceed(t, service.BackendTypeTemporal, nil)
+		doTestStateExecuteApiFailAndProceed(
+			t,
+			service.BackendTypeTemporal,
+			nil,
+			dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED,
+		)
 		smallWaitForFastTest()
-		doTestStateExecuteApiFailAndProceed(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestStateExecuteApiFailAndProceed(
+			t,
+			service.BackendTypeTemporal,
+			minimumContinueAsNewSyncDurabilityConfig(),
+			dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED,
+		)
+		smallWaitForFastTest()
+		doTestStateExecuteApiFailAndProceed(
+			t,
+			service.BackendTypeTemporal,
+			syncDurabilityConfig(),
+			dexpb.StepDurability_STEP_DURABILITY_ASYNC,
+		)
 		smallWaitForFastTest()
 	}
 }
@@ -49,9 +66,19 @@ func TestStateExecuteApiFailAndProceedCadence(t *testing.T) {
 		t.Skip()
 	}
 	for i := 0; i < *repeatIntegTest; i++ {
-		doTestStateExecuteApiFailAndProceed(t, service.BackendTypeCadence, nil)
+		doTestStateExecuteApiFailAndProceed(
+			t,
+			service.BackendTypeCadence,
+			nil,
+			dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED,
+		)
 		smallWaitForFastTest()
-		doTestStateExecuteApiFailAndProceed(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestStateExecuteApiFailAndProceed(
+			t,
+			service.BackendTypeCadence,
+			minimumContinueAsNewSyncDurabilityConfig(),
+			dexpb.StepDurability_STEP_DURABILITY_UNSPECIFIED,
+		)
 		smallWaitForFastTest()
 	}
 }
@@ -60,6 +87,7 @@ func doTestStateExecuteApiFailAndProceed(
 	t *testing.T,
 	backendType service.BackendType,
 	flowConfig *dexpb.FlowConfig,
+	executeDurabilityOverride dexpb.StepDurability,
 ) {
 	workerHandler := wf_execute_api_fail_and_proceed.NewHandler()
 	workerTarget := startWorker(t, workerHandler)
@@ -87,7 +115,8 @@ func doTestStateExecuteApiFailAndProceed(
 			},
 		},
 		StepOptions: &dexpb.StepOptions{
-			SkipWaitFor: true,
+			SkipWaitFor:               true,
+			ExecuteDurabilityOverride: executeDurabilityOverride,
 			ExecuteRetryPolicy: &dexpb.RetryPolicy{
 				MaximumAttempts: 1,
 			},
@@ -112,8 +141,12 @@ func doTestStateExecuteApiFailAndProceed(
 	require.NoError(t, err)
 
 	history := workerHandler.GetTestResult().InvokeHistory
+	expectedExecute := int64(1)
+	if executeDurabilityOverride == dexpb.StepDurability_STEP_DURABILITY_ASYNC {
+		expectedExecute = 2
+	}
 	require.Equal(t, map[string]int64{
-		"S1_execute":      1,
+		"S1_execute":      expectedExecute,
 		"Recover_execute": 1,
 	}, history)
 

--- a/server/integ/wf_state_wait_until_api_fail_and_proceed_test.go
+++ b/server/integ/wf_state_wait_until_api_fail_and_proceed_test.go
@@ -39,7 +39,7 @@ func TestStateApiFailAndProceedTemporal(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestStateApiFailAndProceed(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestStateApiFailAndProceed(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestStateApiFailAndProceed(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -51,7 +51,7 @@ func TestStateApiFailAndProceedCadence(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestStateApiFailAndProceed(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestStateApiFailAndProceed(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestStateApiFailAndProceed(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/wf_stop_test.go
+++ b/server/integ/wf_stop_test.go
@@ -42,17 +42,17 @@ func TestWorkflowCanceledTemporal(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestWorkflowCanceled(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestWorkflowCanceled(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestWorkflowCanceled(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 
 		doTestWorkflowTerminated(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestWorkflowTerminated(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestWorkflowTerminated(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 
 		doTestWorkflowFail(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestWorkflowFail(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestWorkflowFail(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -64,17 +64,17 @@ func TestWorkflowCanceledCadence(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestWorkflowCanceled(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestWorkflowCanceled(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestWorkflowCanceled(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 
 		doTestWorkflowTerminated(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestWorkflowTerminated(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestWorkflowTerminated(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 
 		doTestWorkflowFail(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestWorkflowFail(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestWorkflowFail(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/integ/wf_timeout_test.go
+++ b/server/integ/wf_timeout_test.go
@@ -39,7 +39,7 @@ func TestFlowTimeoutTemporal(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestFlowTimeout(t, service.BackendTypeTemporal, nil)
 		smallWaitForFastTest()
-		doTestFlowTimeout(t, service.BackendTypeTemporal, minimumContinueAsNewConfigV0())
+		doTestFlowTimeout(t, service.BackendTypeTemporal, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }
@@ -51,7 +51,7 @@ func TestFlowTimeoutCadence(t *testing.T) {
 	for i := 0; i < *repeatIntegTest; i++ {
 		doTestFlowTimeout(t, service.BackendTypeCadence, nil)
 		smallWaitForFastTest()
-		doTestFlowTimeout(t, service.BackendTypeCadence, minimumContinueAsNewConfigV0())
+		doTestFlowTimeout(t, service.BackendTypeCadence, minimumContinueAsNewSyncDurabilityConfig())
 		smallWaitForFastTest()
 	}
 }

--- a/server/service/interpreter/config/flowConfiger_test.go
+++ b/server/service/interpreter/config/flowConfiger_test.go
@@ -71,6 +71,10 @@ func TestFlowConfiger_DurabilityPrecedence(t *testing.T) {
 	waitOverride := &dexpb.StepOptions{WaitForDurabilityOverride: dexpb.StepDurability_STEP_DURABILITY_SYNC}
 	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_SYNC, flowConfiger.ResolveWaitForDurability(waitOverride))
 	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_ASYNC, flowConfiger.ResolveExecuteDurability(waitOverride))
+
+	executeOverride := &dexpb.StepOptions{ExecuteDurabilityOverride: dexpb.StepDurability_STEP_DURABILITY_SYNC}
+	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_ASYNC, flowConfiger.ResolveWaitForDurability(executeOverride))
+	assert.Equal(t, dexpb.StepDurability_STEP_DURABILITY_SYNC, flowConfiger.ResolveExecuteDurability(executeOverride))
 }
 
 func TestFlowConfiger_UpdateByAPIPartialOverride(t *testing.T) {


### PR DESCRIPTION
## Summary
- Set the server default workflow config to use async step durability explicitly.
- Replace ad hoc continue-as-new config builders in integration tests with named async/sync helpers.
- Expand state API failure and proceed coverage to validate durability override behavior.

## Testing
- Not run (not requested)
- Existing integration coverage was updated to exercise the new async and sync durability helpers across Temporal and Cadence paths