### PR TITLE
Stabilize S3 cleanup integration timeout

### DIFF
--- a/server/integ/s3_cleanup_test.go
+++ b/server/integ/s3_cleanup_test.go
@@ -64,7 +64,7 @@ func doTestWorkflowWithS3Cleanup(t *testing.T, backendType service.BackendType) 
 	flowClient := runtime.FlowClient
 	unifiedClient := runtime.UnifiedClient
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	flowIds := make([]string, 0, 24)


### PR DESCRIPTION
## Summary

- increase the S3 cleanup integration test context budget from 120 seconds to 5 minutes
- keep the existing 30,000-object coverage and the Server CI job's 35-minute outer timeout unchanged

## Root cause

Main's latest Server CI first attempt failed only in `Cadence integration (partition 4)`. `TestS3CleanupCadence` uses one context for roughly 30,000 sequential S3 writes plus validation and cleanup. The run exhausted that fixed 120-second context and failed with `PutObject, context deadline exceeded` at 120.02 seconds; rerunning the same commit passed in 74.52 seconds.

## Impact

This removes runner-speed sensitivity from the high-volume S3 cleanup integration test without weakening its assertions or skipping coverage.

## Validation

- `make copyright-check`
- `make -C server unitTests`
- `make -C server ci-cadence-integ-test totalPartitions=5 partitionNum=4` (`TestS3CleanupCadence` passed in 56.73s; full partition passed in 88.051s)
