### PR TITLE
Improve RPC history configuration and local activity payload logging

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -117,8 +117,8 @@ type (
 		MaxWaitSeconds int64 `yaml:"maxWaitSeconds"`
 		// GrpcMaxMessageBytes is MaxRecv/MaxSend for FlowService, InternalService, and WorkerService clients. Default 16 MiB. Must be positive and larger than continue-as-new page size plus overhead.
 		GrpcMaxMessageBytes int `yaml:"grpcMaxMessageBytes"`
-		// OmitRpcInputOutputInHistory omits RPC input/output from Temporal/Cadence history when true. Default nil/false keeps I/O for debugging.
-		OmitRpcInputOutputInHistory *bool `yaml:"omitRpcInputOutputInHistory"`
+		// IncludeRPCInputOutputIntoHistory stores RPC input/output in Temporal/Cadence history for debugging. Default false.
+		IncludeRPCInputOutputIntoHistory bool `yaml:"includeRPCInputOutputIntoHistory"`
 		// QueryWorkflowFailedRetryPolicy retries failed Describe/Query calls against the backend.
 		QueryWorkflowFailedRetryPolicy QueryWorkflowFailedRetryPolicy `yaml:"queryWorkflowFailedRetryPolicy"`
 	}

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -189,6 +189,7 @@ func (s *serviceImpl) StartFlow(
 				Payload: []byte(workerTarget),
 			},
 		},
+		IdReusePolicy: ptr.Any(dexpb.IdReusePolicy_ID_REUSE_POLICY_ALLOW_IF_NO_RUNNING),
 	}
 	ignoreAlreadyStartedError := false
 	requestId := ""
@@ -733,16 +734,14 @@ func (s *serviceImpl) InvokeRPC(
 		len(decision.GetNextSteps()) > 0 ||
 		decision.GetConditionalClose() != nil {
 		signalRequest := &dexpb.ExecuteRpcSignalRequest{
-			RpcInput:         req.GetInput(),
-			RpcOutput:        workerResponse.GetOutput(),
 			UpsertAttributes: workerResponse.GetUpsertAttributes(),
 			StepDecision:     workerResponse.GetStepDecision(),
 			RecordEvents:     workerResponse.GetRecordEvents(),
 			PublishToChannel: workerResponse.GetPublishToChannel(),
 		}
-		if s.apiCfg.OmitRpcInputOutputInHistory != nil && *s.apiCfg.OmitRpcInputOutputInHistory {
-			signalRequest.RpcInput = nil
-			signalRequest.RpcOutput = nil
+		if s.apiCfg.IncludeRPCInputOutputIntoHistory {
+			signalRequest.RpcInput = req.GetInput()
+			signalRequest.RpcOutput = workerResponse.GetOutput()
 		}
 		if err := s.client.SignalWorkflow(
 			ctx,

--- a/server/service/interpreter/activityImpl.go
+++ b/server/service/interpreter/activityImpl.go
@@ -23,6 +23,7 @@ package interpreter
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -91,7 +92,7 @@ func (a *Activities) InvokeWaitForMethod(
 
 	if !a.cfg.ExternalStorage.EffectiveLazyLoading() {
 		if err := a.hydrateWorkerRequestValues(ctx, req.GetStepInput(), req.GetAttributes()); err != nil {
-			a.logLocalActivityWarn(logger, activityInfo, "InvokeWaitForMethod", req.GetContext().GetStepExecutionId(), err)
+			a.logLocalActivityWarn(logger, activityInfo, "InvokeWaitForMethod", req.GetContext().GetStepExecutionId(), req, err)
 			return nil, composeInternalActivityError(provider, err)
 		}
 	}
@@ -106,7 +107,7 @@ func (a *Activities) InvokeWaitForMethod(
 	printDebugMsg(logger, err, input.GetWorkerTarget())
 	if err != nil {
 		a.emitStepWaitForMethodEvent(req, activityInfo, "WAIT_FOR_ATTEMPT_FAIL")
-		a.logLocalActivityWarn(logger, activityInfo, "InvokeWaitForMethod", req.GetContext().GetStepExecutionId(), err)
+		a.logLocalActivityWarn(logger, activityInfo, "InvokeWaitForMethod", req.GetContext().GetStepExecutionId(), req, err)
 		return nil, composeActivityError(provider, err)
 	}
 	if err := validateWaitingCondition(resp.GetWaitingCondition()); err != nil {
@@ -149,7 +150,7 @@ func (a *Activities) InvokeExecuteMethod(
 	originalStepInputBlob := stepInputBlobRef(req.GetStepInput())
 	if !lazyLoading {
 		if err := a.hydrateWorkerRequestValues(ctx, req.GetStepInput(), req.GetAttributes()); err != nil {
-			a.logLocalActivityWarn(logger, activityInfo, "InvokeExecuteMethod", req.GetContext().GetStepExecutionId(), err)
+			a.logLocalActivityWarn(logger, activityInfo, "InvokeExecuteMethod", req.GetContext().GetStepExecutionId(), req, err)
 			return nil, composeInternalActivityError(provider, err)
 		}
 		if err := blobstore.HydrateKVs(ctx, req.GetStepExeLocals(), a.blobStore); err != nil {
@@ -167,7 +168,7 @@ func (a *Activities) InvokeExecuteMethod(
 	printDebugMsg(logger, err, input.GetWorkerTarget())
 	if err != nil {
 		a.emitStepExecuteMethodEvent(req, activityInfo, "EXECUTE_ATTEMPT_FAIL")
-		a.logLocalActivityWarn(logger, activityInfo, "InvokeExecuteMethod", req.GetContext().GetStepExecutionId(), err)
+		a.logLocalActivityWarn(logger, activityInfo, "InvokeExecuteMethod", req.GetContext().GetStepExecutionId(), req, err)
 		return nil, composeActivityError(provider, err)
 	}
 	if err := validateStepDecision(resp.GetStepDecision()); err != nil {
@@ -246,11 +247,11 @@ func (a *Activities) InvokeWorkerRPC(
 	}
 	out := &dexpb.InvokeWorkerRPCActivityOutput{Response: resp}
 	if activityInfo.IsLocalActivity {
-		payload := log.ToJsonAndTruncateForLogging(out)
-		if threshold := a.cfg.Interpreter.InterpreterActivityConfig.LogLocalActivityThresholdBytes; threshold > 0 && len(payload) >= threshold {
+		payloadSize, sized := jsonPayloadSize(logger, out)
+		if threshold := a.cfg.Interpreter.InterpreterActivityConfig.LogLocalActivityThresholdBytes; sized && threshold > 0 && payloadSize >= threshold {
 			logger.Warn("InvokeWorkerRpc local activity return",
 				"workflowId", activityInfo.WorkflowExecution.ID,
-				"payloadSize", len(payload))
+				"payloadSize", payloadSize)
 		}
 	}
 	return out, nil
@@ -709,15 +710,30 @@ func composeInternalActivityError(
 
 func (a *Activities) logLocalActivityWarn(
 	logger interfaces.UnifiedLogger,
-	activityInfo interfaces.ActivityInfo, name, stepExeId string, err error,
+	activityInfo interfaces.ActivityInfo, name, stepExeId string, payload any, err error,
 ) {
-	if !activityInfo.IsLocalActivity || a.cfg.Interpreter.InterpreterActivityConfig.LogLocalActivityThresholdBytes <= 0 {
+	threshold := a.cfg.Interpreter.InterpreterActivityConfig.LogLocalActivityThresholdBytes
+	if !activityInfo.IsLocalActivity || threshold <= 0 {
+		return
+	}
+	payloadSize, sized := jsonPayloadSize(logger, payload)
+	if !sized || payloadSize < threshold {
 		return
 	}
 	logger.Warn(name+" local activity return on error",
 		"workflowId", activityInfo.WorkflowExecution.ID,
 		"stepExecutionId", stepExeId,
+		"payloadSize", payloadSize,
 		"error", err)
+}
+
+func jsonPayloadSize(logger interfaces.UnifiedLogger, payload any) (int, bool) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		logger.Error("Failed to serialize local activity payload", "error", err)
+		return 0, false
+	}
+	return len(payloadBytes), true
 }
 
 func (a *Activities) emitStepWaitForMethodEvent(


### PR DESCRIPTION
## Summary

- Replace the pointer-based RPC history omission setting with an explicit `includeRPCInputOutputIntoHistory` flag.
- Allow workflow ID reuse when no matching workflow is running.
- Log local activity payload sizes using JSON serialization, including error paths.

## Testing

Not run (not requested).