### PR TITLE
Preserve sub-second wait deadlines

### DIFF
--- a/server/service/common/utils/utils.go
+++ b/server/service/common/utils/utils.go
@@ -96,19 +96,15 @@ func TrimContextByTimeoutWithCappedDDL(parent context.Context, reqWaitSeconds *i
 		maxWaitSeconds = int64(*reqWaitSeconds)
 	}
 
-	maxWaitTimestamp := time.Now().Unix() + maxWaitSeconds
+	maxWaitDeadline := time.Now().Add(time.Duration(maxWaitSeconds) * time.Second)
 
 	// then capped by context
 	ddl, ok := parent.Deadline()
-	if ok {
-		maxDdlUnix := ddl.Unix()
-		if maxDdlUnix < maxWaitTimestamp {
-			maxWaitTimestamp = maxDdlUnix
-		}
+	if ok && ddl.Before(maxWaitDeadline) {
+		maxWaitDeadline = ddl
 	}
 
-	newDdl := time.Unix(maxWaitTimestamp, 0)
-	return context.WithDeadline(parent, newDdl)
+	return context.WithDeadline(parent, maxWaitDeadline)
 }
 
 func CheckHttpError(err error, httpResp *http.Response) bool {

--- a/server/service/common/utils/utils.go
+++ b/server/service/common/utils/utils.go
@@ -96,6 +96,7 @@ func TrimContextByTimeoutWithCappedDDL(parent context.Context, reqWaitSeconds *i
 		maxWaitSeconds = int64(*reqWaitSeconds)
 	}
 
+	// Preserve sub-second precision so short waits are not truncated near second boundaries.
 	maxWaitDeadline := time.Now().Add(time.Duration(maxWaitSeconds) * time.Second)
 
 	// then capped by context


### PR DESCRIPTION
## Summary

- preserve sub-second precision when calculating capped API wait deadlines
- continue honoring an earlier caller context deadline

## Root cause

`TrimContextByTimeoutWithCappedDDL` converted both deadlines to Unix seconds. Truncating the fractional second could reduce a requested one-second wait to only a few milliseconds when the request arrived near a second boundary, causing intermittent `DeadlineExceeded` responses.

## Impact

Wait APIs now receive the full configured/requested duration while still being capped by the parent context.

## Validation

- `make copyright-check`
- `make -C server unitTests`
- `make -C server ci-temporal-integ-test totalPartitions=5 partitionNum=2`
