### PR TITLE
Add integ test for persistence attribute deletion across workflow transitions

### DIFF
--- a/server/integ/persistence_test.go
+++ b/server/integ/persistence_test.go
@@ -236,7 +236,6 @@ func doTestPersistenceWorkflow(
 	}, data)
 
 	expectedVal1 := dataObjectAttribute(persistence.TestDataAttributeKey, "test-data-attribute-value2")
-	expectedVal2 := dataObjectAttribute(persistence.TestDataAttributeKey2, "test-data-attribute-value1")
 
 	requireAttributesMatch(t, []*dexpb.AttributeWrite{
 		expectedVal1,
@@ -244,9 +243,9 @@ func doTestPersistenceWorkflow(
 	}, queryResult1.GetAttributes())
 	requireAttributesMatch(t, []*dexpb.AttributeWrite{
 		expectedVal1,
-		expectedVal2,
 		expectedDataAttribute,
 	}, queryResult2.GetAttributes())
+	requireAttributeAbsent(t, queryResult2.GetAttributes(), persistence.TestDataAttributeKey2)
 
 	expectedSearchKeyword := indexedKeywordAttribute(
 		persistence.TestSearchAttributeKeywordKey,
@@ -440,6 +439,13 @@ func requireAttributePresent(t *testing.T, attributes []*dexpb.KV, expected *dex
 		}
 	}
 	require.Fail(t, "expected attribute not found", expected.GetKey())
+}
+
+func requireAttributeAbsent(t *testing.T, attributes []*dexpb.KV, key string) {
+	t.Helper()
+	for _, attribute := range attributes {
+		require.NotEqual(t, key, attribute.GetKey(), "unexpected attribute found")
+	}
 }
 
 func requireSearchAttributesMatch(

--- a/server/integ/workflow/persistence/routers.go
+++ b/server/integ/workflow/persistence/routers.go
@@ -153,13 +153,11 @@ func (h *handler) InvokeWaitForMethod(
 			return nil, status.Error(codes.InvalidArgument, "should see the requested attribute key")
 		}
 
-		queryAttFound := countAttributesWithKeys(
-			request.GetAttributes(),
-			TestDataAttributeKey,
-			TestDataAttributeKey2,
-		)
-		if queryAttFound != 2 {
-			return nil, status.Error(codes.InvalidArgument, "missing query attribute keys")
+		if countAttributesWithKeys(request.GetAttributes(), TestDataAttributeKey) != 1 {
+			return nil, status.Error(codes.InvalidArgument, "missing query attribute key")
+		}
+		if countAttributesWithKeys(request.GetAttributes(), TestDataAttributeKey2) != 0 {
+			return nil, status.Error(codes.InvalidArgument, "deleted query attribute key is still present")
 		}
 
 		return &dexpb.InvokeWaitForMethodResponse{
@@ -241,6 +239,9 @@ func (h *handler) InvokeExecuteMethod(
 					{StepType: State3},
 				},
 			},
+			UpsertAttributes: []*dexpb.AttributeWrite{
+				deleteAttribute(TestDataAttributeKey2),
+			},
 		}, nil
 	case State3:
 		foundInt := attributeIntMatches(
@@ -252,13 +253,11 @@ func (h *handler) InvokeExecuteMethod(
 			return nil, status.Error(codes.InvalidArgument, "should see the requested attribute key")
 		}
 
-		queryAttFound := countAttributesWithKeys(
-			request.GetAttributes(),
-			TestDataAttributeKey,
-			TestDataAttributeKey2,
-		)
-		if queryAttFound != 2 {
-			return nil, status.Error(codes.InvalidArgument, "missing query attribute keys")
+		if countAttributesWithKeys(request.GetAttributes(), TestDataAttributeKey) != 1 {
+			return nil, status.Error(codes.InvalidArgument, "missing query attribute key")
+		}
+		if countAttributesWithKeys(request.GetAttributes(), TestDataAttributeKey2) != 0 {
+			return nil, status.Error(codes.InvalidArgument, "deleted query attribute key is still present")
 		}
 
 		return &dexpb.InvokeExecuteMethodResponse{
@@ -426,5 +425,14 @@ func dataObjectWrite(key, payload string) *dexpb.AttributeWrite {
 	return &dexpb.AttributeWrite{
 		Key:   key,
 		Value: jsonObjValue(payload),
+	}
+}
+
+func deleteAttribute(key string) *dexpb.AttributeWrite {
+	return &dexpb.AttributeWrite{
+		Key: key,
+		Value: &dexpb.Value{
+			Kind: &dexpb.Value_NullValue{},
+		},
 	}
 }


### PR DESCRIPTION
## Summary

- Update persistence integration coverage to delete an attribute via a null upsert.
- Verify deleted attributes are absent from subsequent workflow queries.
- Add a helper for asserting attribute absence.

## Testing

- Updated persistence integration test expectations and validation paths.