### PR TITLE
Refactor blob cleanup strategy configuration

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -45,6 +45,10 @@ const (
 )
 
 const (
+	CleanupStrategyTypeAfterAllRunsDeleted CleanupStrategyType = "afterAllRunsDeleted"
+)
+
+const (
 	// DefaultApiPort is the default FlowService/InternalService gRPC bind port.
 	DefaultApiPort = 8801
 	// DefaultMaxWaitSeconds caps WaitForFlow / WaitForStepCompletion / WaitForAttribute when MaxWaitSeconds is 0.
@@ -96,13 +100,20 @@ type (
 		ThresholdInBytes int `yaml:"thresholdInBytes"`
 		// SupportedStorages lists blob backends. Exactly one may have Status active for writes; others are read-only.
 		SupportedStorages []BlobStorageConfig `yaml:"supportedStorages"`
-		// MinAgeForCleanupCheckInDays stops cleanup scans for objects newer than now minus this many days. Align with Temporal/Cadence retention.
-		// Default 0 means no age gate. Need to manually set as it needs to align with Temporal/Cadence retention.
-		MinAgeForCleanupCheckInDays int `yaml:"minAgeForCleanupCheckInDays"`
+		// HistoryRetentionInDays must match the Temporal/Cadence history retention. Default 0; configure it explicitly.
+		HistoryRetentionInDays int `yaml:"historyRetentionInDays"`
 	}
 
-	StorageStatus string
-	StorageType   string
+	StorageStatus       string
+	StorageType         string
+	CleanupStrategyType string
+
+	CleanupStrategy struct {
+		// CleanupStrategyType selects cleanup eligibility. Default and only supported value: afterAllRunsDeleted.
+		CleanupStrategyType CleanupStrategyType `yaml:"cleanupStrategyType"`
+		// CleanupFrequencyInDays schedules cleanup at midnight every Nth day-of-month. Default 0 disables scheduled cleanup.
+		CleanupFrequencyInDays int `yaml:"cleanupFrequencyInDays"`
+	}
 
 	BlobStorageConfig struct {
 		// Status is "active" (writable) or "inactive" (read-only). Only one active store is allowed.
@@ -121,8 +132,8 @@ type (
 		S3AccessKey string `yaml:"s3AccessKey"`
 		// S3SecretKey is the secret access key for S3 auth.
 		S3SecretKey string `yaml:"s3SecretKey"`
-		// CleanupCronSchedule is a standard cron for the blob cleanup workflow. Empty disables cleanup.
-		CleanupCronSchedule string `yaml:"cleanupCronSchedule"`
+		// CleanupStrategy controls automatic blob cleanup. Default type is afterAllRunsDeleted; zero frequency disables scheduling.
+		CleanupStrategy CleanupStrategy `yaml:"cleanupStrategy"`
 	}
 
 	ApiConfig struct {
@@ -283,6 +294,26 @@ func (c ExternalStorageConfig) EffectiveLazyLoading() bool {
 		return true
 	}
 	return *c.LazyLoading
+}
+
+func (c CleanupStrategy) CronSchedule() (string, error) {
+	strategyType := c.CleanupStrategyType
+	if strategyType == "" {
+		strategyType = CleanupStrategyTypeAfterAllRunsDeleted
+	}
+	if strategyType != CleanupStrategyTypeAfterAllRunsDeleted {
+		return "", fmt.Errorf("unsupported cleanup strategy type: %s", strategyType)
+	}
+	if c.CleanupFrequencyInDays < 0 {
+		return "", fmt.Errorf("cleanup frequency in days must be non-negative")
+	}
+	if c.CleanupFrequencyInDays == 0 {
+		return "", nil
+	}
+	if c.CleanupFrequencyInDays == 1 {
+		return "0 0 * * *", nil
+	}
+	return fmt.Sprintf("0 0 */%d * *", c.CleanupFrequencyInDays), nil
 }
 
 // EffectiveGrpcMaxMessageBytes returns GrpcMaxMessageBytes or DefaultGrpcMaxMessageBytes.

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupStrategyCronSchedule(t *testing.T) {
+	testCases := []struct {
+		name             string
+		strategy         CleanupStrategy
+		expectedSchedule string
+		expectError      bool
+	}{
+		{
+			name: "default strategy disabled",
+		},
+		{
+			name: "default strategy daily",
+			strategy: CleanupStrategy{
+				CleanupFrequencyInDays: 1,
+			},
+			expectedSchedule: "0 0 * * *",
+		},
+		{
+			name: "explicit strategy every three days",
+			strategy: CleanupStrategy{
+				CleanupStrategyType:    CleanupStrategyTypeAfterAllRunsDeleted,
+				CleanupFrequencyInDays: 3,
+			},
+			expectedSchedule: "0 0 */3 * *",
+		},
+		{
+			name: "unsupported strategy",
+			strategy: CleanupStrategy{
+				CleanupStrategyType: "unsupported",
+			},
+			expectError: true,
+		},
+		{
+			name: "negative frequency",
+			strategy: CleanupStrategy{
+				CleanupFrequencyInDays: -1,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			schedule, err := testCase.strategy.CronSchedule()
+			if testCase.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedSchedule, schedule)
+		})
+	}
+}

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -19,7 +19,7 @@ interpreter:
 externalStorage:
   enabled: true
   thresholdInBytes: 100000 # 100 KB
-  minAgeForCleanupCheckInDays: 3
+  historyRetentionInDays: 3
   supportedStorages:
     - status: active
       storageId: "local-dev-s3"
@@ -29,4 +29,6 @@ externalStorage:
       s3Region: "us-east-1"
       s3AccessKey: "minioadmin"
       s3SecretKey: "minioadmin"
-      cleanupCronSchedule: "0 0 * * *" #every day at 00:00
+      cleanupStrategy:
+        cleanupStrategyType: afterAllRunsDeleted
+        cleanupFrequencyInDays: 1

--- a/server/integ/config.go
+++ b/server/integ/config.go
@@ -64,10 +64,10 @@ func createTestConfig(testCfg DexServiceTestConfig) config.Config {
 	}
 	if testCfg.S3TestThreshold > 0 {
 		externalStorage := config.ExternalStorageConfig{
-			Enabled:                     true,
-			LazyLoading:                 testCfg.LazyLoading,
-			ThresholdInBytes:            testCfg.S3TestThreshold,
-			MinAgeForCleanupCheckInDays: 3,
+			Enabled:                true,
+			LazyLoading:            testCfg.LazyLoading,
+			ThresholdInBytes:       testCfg.S3TestThreshold,
+			HistoryRetentionInDays: 3,
 			SupportedStorages: []config.BlobStorageConfig{
 				{
 					Status:      config.StorageStatusActive,

--- a/server/service/interpreter/activityImpl.go
+++ b/server/service/interpreter/activityImpl.go
@@ -294,14 +294,14 @@ func (a *Activities) InvokeWorkerRPC(
 	return out, nil
 }
 
-// CleanupBlobStore deletes blob objects for flows that no longer exist in the backend.
-func (a *Activities) CleanupBlobStore(
+// CleanupBlobsAfterAllRunsDeleted deletes blobs after the backend removes every run.
+func (a *Activities) CleanupBlobsAfterAllRunsDeleted(
 	ctx context.Context, input *dexpb.CleanupBlobStoreActivityInput,
 ) (*dexpb.CleanupBlobStoreActivityOutput, error) {
 	store := a.blobStore
 	provider := a.activityProvider
 	logger := provider.GetLogger(ctx)
-	logger.Info("CleanupBlobStore started")
+	logger.Info("CleanupBlobsAfterAllRunsDeleted started")
 	client := a.unifiedClient
 
 	var continueToken *string
@@ -318,20 +318,20 @@ func (a *Activities) CleanupBlobStore(
 		for _, workflowPath := range listOutput.WorkflowPaths {
 			_, valid := blobstore.ExtractYyyymmddToUnixSeconds(workflowPath)
 			if !valid {
-				logger.Info("CleanupBlobStore skipped workflow path", "path", workflowPath)
+				logger.Info("CleanupBlobsAfterAllRunsDeleted skipped workflow path", "path", workflowPath)
 				continue
 			}
 			flowId := blobstore.MustExtractWorkflowId(workflowPath)
 			_, err := client.DescribeWorkflowExecution(ctx, flowId, "", nil)
 			if client.IsNotFoundError(err) {
 				if err := store.DeleteWorkflowObjects(ctx, input.GetStoreId(), workflowPath); err != nil {
-					logger.Error("CleanupBlobStore failed to delete workflow objects", "workflowPath", workflowPath, "error", err)
+					logger.Error("CleanupBlobsAfterAllRunsDeleted failed to delete workflow objects", "workflowPath", workflowPath, "error", err)
 					return nil, err
 				}
 				totalDeleted++
-				logger.Info("CleanupBlobStore deleted workflow objects", "workflowPath", workflowPath)
+				logger.Info("CleanupBlobsAfterAllRunsDeleted deleted workflow objects", "workflowPath", workflowPath)
 			} else if err != nil {
-				logger.Error("CleanupBlobStore failed to describe workflow", "workflowPath", workflowPath, "error", err)
+				logger.Error("CleanupBlobsAfterAllRunsDeleted failed to describe workflow", "workflowPath", workflowPath, "error", err)
 				return nil, err
 			}
 			provider.RecordHeartbeat(ctx)
@@ -340,7 +340,7 @@ func (a *Activities) CleanupBlobStore(
 			break
 		}
 	}
-	logger.Info("CleanupBlobStore completed", "totalDeleted", totalDeleted)
+	logger.Info("CleanupBlobsAfterAllRunsDeleted completed", "totalDeleted", totalDeleted)
 	return &dexpb.CleanupBlobStoreActivityOutput{TotalDeleted: totalDeleted}, nil
 }
 

--- a/server/service/interpreter/cadence/worker.go
+++ b/server/service/interpreter/cadence/worker.go
@@ -145,7 +145,7 @@ func (iw *InterpreterWorker) doStart(disableStickyCache bool) {
 	iw.worker.RegisterActivity(iw.activities.InvokeExecuteMethod)
 	iw.worker.RegisterActivity(iw.activities.DumpFlowForContinueAsNew)
 	iw.worker.RegisterActivity(iw.activities.InvokeWorkerRPC)
-	iw.worker.RegisterActivity(iw.activities.CleanupBlobStore)
+	iw.worker.RegisterActivity(iw.activities.CleanupBlobsAfterAllRunsDeleted)
 
 	err := iw.worker.Start()
 	if err != nil {
@@ -154,11 +154,15 @@ func (iw *InterpreterWorker) doStart(disableStickyCache bool) {
 
 	if iw.cfg.ExternalStorage.Enabled {
 		for _, storeCfg := range iw.cfg.ExternalStorage.SupportedStorages {
-			if storeCfg.CleanupCronSchedule != "" {
+			cronSchedule, scheduleErr := storeCfg.CleanupStrategy.CronSchedule()
+			if scheduleErr != nil {
+				log.Fatalln("Invalid blobstore cleanup strategy", scheduleErr)
+			}
+			if cronSchedule != "" {
 				err = iw.unifiedClient.StartBlobStoreCleanupWorkflow(
 					context.Background(), iw.tasklist,
 					"blobstore-cleanup-"+storeCfg.StorageId,
-					storeCfg.CleanupCronSchedule,
+					cronSchedule,
 					storeCfg.StorageId)
 				if err != nil {
 					if iw.unifiedClient.IsWorkflowAlreadyStartedError(err) {

--- a/server/service/interpreter/temporal/worker.go
+++ b/server/service/interpreter/temporal/worker.go
@@ -149,7 +149,7 @@ func (iw *InterpreterWorker) start(disableStickyCache bool) {
 	iw.worker.RegisterActivity(iw.activities.InvokeExecuteMethod)
 	iw.worker.RegisterActivity(iw.activities.DumpFlowForContinueAsNew)
 	iw.worker.RegisterActivity(iw.activities.InvokeWorkerRPC)
-	iw.worker.RegisterActivity(iw.activities.CleanupBlobStore)
+	iw.worker.RegisterActivity(iw.activities.CleanupBlobsAfterAllRunsDeleted)
 
 	err := iw.worker.Start()
 	if err != nil {
@@ -158,11 +158,15 @@ func (iw *InterpreterWorker) start(disableStickyCache bool) {
 
 	if iw.cfg.ExternalStorage.Enabled {
 		for _, storeCfg := range iw.cfg.ExternalStorage.SupportedStorages {
-			if storeCfg.CleanupCronSchedule != "" {
+			cronSchedule, scheduleErr := storeCfg.CleanupStrategy.CronSchedule()
+			if scheduleErr != nil {
+				log.Fatalln("Invalid blobstore cleanup strategy", scheduleErr)
+			}
+			if cronSchedule != "" {
 				err = iw.unifiedClient.StartBlobStoreCleanupWorkflow(
 					context.Background(), iw.taskQueue,
 					"blobstore-cleanup-"+storeCfg.StorageId,
-					storeCfg.CleanupCronSchedule,
+					cronSchedule,
 					storeCfg.StorageId)
 				if err != nil {
 					if iw.unifiedClient.IsWorkflowAlreadyStartedError(err) {

--- a/server/service/interpreter/workflowImpl.go
+++ b/server/service/interpreter/workflowImpl.go
@@ -1029,7 +1029,7 @@ func (i *Interpreter) BlobStoreCleanup(
 		&output,
 		dexpb.StepDurability_STEP_DURABILITY_SYNC,
 		activityCtx,
-		i.activities.CleanupBlobStore,
+		i.activities.CleanupBlobsAfterAllRunsDeleted,
 		&dexpb.CleanupBlobStoreActivityInput{
 			StoreId: storeId,
 		},


### PR DESCRIPTION
## Summary

- Rename the blob cleanup activity implementation to `CleanupBlobsAfterAllRunsDeleted`.
- Rename `MinAgeForCleanupCheckInDays` to `HistoryRetentionInDays`.
- Replace the per-storage raw `CleanupCronSchedule` with a typed `CleanupStrategy` containing `CleanupStrategyType` and `CleanupFrequencyInDays`.
- Default the strategy type to `afterAllRunsDeleted` and assemble the Temporal/Cadence cron schedule during worker startup.

## Why

The new names describe the actual cleanup condition and remove raw cron syntax from server configuration. Cleanup frequency is now expressed in days while the server owns backend scheduling details.

## Impact

This intentionally changes the internal server configuration keys. A zero cleanup frequency disables automatic cleanup; unsupported strategy values and negative frequencies fail during startup.

## Testing

- `make -C server unitTests`
- Focused cleanup strategy cron unit test
- Temporal S3 cleanup integration test
- Cadence S3 cleanup integration test
- `make copyright-check`
