### PR TITLE
Validate required Temporal search attributes in dev mode

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -42,7 +42,7 @@ dexcli dev --temporal-address localhost:7233
 ```
 
 External mode does not start or stop Temporal. The target namespace must
-already contain a `FlowType` search attribute of type `Keyword`.
+already contain `FlowType` (`Keyword`) and `ActiveStepTypes` (`KeywordList`).
 
 Select another namespace with `--temporal-namespace`. The first release uses
 plaintext endpoints; Temporal Cloud authentication is not supported yet.
@@ -81,5 +81,5 @@ binary does not read `web/`, `node_modules`, or the source tree.
 - “Temporal CLI was not found”: reinstall `dexcli` with Homebrew or install the
   `temporal` formula.
 - “address is already in use”: stop the listed service or select another port.
-- “missing search attribute FlowType”: create `FlowType` as `Keyword` in the
-  selected external namespace.
+- “missing search attribute”: register `FlowType` as `Keyword` and
+  `ActiveStepTypes` as `KeywordList` in the selected external namespace.

--- a/cli/internal/dev/supervisor.go
+++ b/cli/internal/dev/supervisor.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/superdurable/dex/config"
 	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service"
 	"github.com/superdurable/dex/service/bootstrap"
 	dexweb "github.com/superdurable/dex/web"
 	"github.com/superdurable/dex/web/assets"
@@ -100,7 +101,7 @@ func (s *supervisor) Run(ctx context.Context) (runErr error) {
 		}
 		return err
 	}
-	if err := validateFlowType(startupCtx, temporalClient, s.cfg.TemporalNamespace); err != nil {
+	if err := validateSearchAttributes(startupCtx, temporalClient, s.cfg.TemporalNamespace); err != nil {
 		temporalClient.Close()
 		if ctx.Err() != nil {
 			return nil
@@ -336,7 +337,7 @@ func waitForTemporal(
 	}
 }
 
-func validateFlowType(ctx context.Context, temporalClient temporalclient.Client, namespace string) error {
+func validateSearchAttributes(ctx context.Context, temporalClient temporalclient.Client, namespace string) error {
 	response, err := temporalClient.OperatorService().ListSearchAttributes(
 		ctx,
 		&operatorservicepb.ListSearchAttributesRequest{Namespace: namespace},
@@ -344,12 +345,31 @@ func validateFlowType(ctx context.Context, temporalClient temporalclient.Client,
 	if err != nil {
 		return fmt.Errorf("list Temporal search attributes for namespace %q: %w", namespace, err)
 	}
-	attributeType, exists := response.GetCustomAttributes()["FlowType"]
-	if !exists {
-		return fmt.Errorf("Temporal namespace %q is missing search attribute FlowType (Keyword)", namespace)
+	requiredAttributes := []struct {
+		name          string
+		attributeType enumspb.IndexedValueType
+	}{
+		{service.SearchAttributeDexWorkflowType, enumspb.INDEXED_VALUE_TYPE_KEYWORD},
+		{service.SearchAttributeActiveStepTypes, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST},
 	}
-	if attributeType != enumspb.INDEXED_VALUE_TYPE_KEYWORD {
-		return fmt.Errorf("Temporal search attribute FlowType must be Keyword, got %s", attributeType)
+	for _, requiredAttribute := range requiredAttributes {
+		attributeType, exists := response.GetCustomAttributes()[requiredAttribute.name]
+		if !exists {
+			return fmt.Errorf(
+				"Temporal namespace %q is missing search attribute %s (%s)",
+				namespace,
+				requiredAttribute.name,
+				requiredAttribute.attributeType,
+			)
+		}
+		if attributeType != requiredAttribute.attributeType {
+			return fmt.Errorf(
+				"Temporal search attribute %s must be %s, got %s",
+				requiredAttribute.name,
+				requiredAttribute.attributeType,
+				attributeType,
+			)
+		}
 	}
 	return nil
 }

--- a/cli/internal/dev/supervisor_integ_test.go
+++ b/cli/internal/dev/supervisor_integ_test.go
@@ -118,7 +118,7 @@ func TestExternalTemporalRemainsRunning(t *testing.T) {
 		cancelStartup()
 		t.Fatal(err)
 	}
-	if err := validateFlowType(startupCtx, temporalClient, localConfig.TemporalNamespace); err != nil {
+	if err := validateSearchAttributes(startupCtx, temporalClient, localConfig.TemporalNamespace); err != nil {
 		temporalClient.Close()
 		cancelStartup()
 		t.Fatal(err)

--- a/cli/internal/dev/temporal_process.go
+++ b/cli/internal/dev/temporal_process.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/superdurable/dex/service"
 )
 
 type temporalProcess struct {
@@ -49,7 +51,8 @@ func startTemporalProcess(cfg *Config, stdout io.Writer, stderr io.Writer) (*tem
 		"--port", strconv.Itoa(cfg.TemporalPort),
 		"--ui-ip", cfg.BindAddress,
 		"--ui-port", strconv.Itoa(cfg.TemporalUIPort),
-		"--search-attribute", "FlowType=Keyword",
+		"--search-attribute", service.SearchAttributeDexWorkflowType + "=Keyword",
+		"--search-attribute", service.SearchAttributeActiveStepTypes + "=KeywordList",
 	}
 	if cfg.TemporalNamespace != defaultTemporalNamespace {
 		arguments = append(arguments, "--namespace", cfg.TemporalNamespace)

--- a/server/lite/start-lite-server.sh
+++ b/server/lite/start-lite-server.sh
@@ -33,13 +33,11 @@ echo "now trying to register Dex system search attributes..."
 
 for run in {1..60}; do
   sleep 1
-  temporal  operator search-attribute  create --name DexWorkflowType --type Keyword
+  temporal  operator search-attribute  create --name FlowType --type Keyword
   sleep 0.1
-  temporal  operator search-attribute  create --name DexGlobalWorkflowVersion --type Int 
+  temporal  operator search-attribute  create --name ActiveStepTypes --type KeywordList
   sleep 0.1
-  temporal  operator search-attribute  create --name DexExecutingStateIds --type KeywordList 
-  sleep 0.1
-  if checkExists "DexWorkflowType" && checkExists "DexGlobalWorkflowVersion" && checkExists "DexExecutingStateIds" ; then
+  if checkExists "FlowType" && checkExists "ActiveStepTypes" ; then
       echo "All search attributes are registered"
       break
     fi


### PR DESCRIPTION
## Summary

- Require both `FlowType` (`Keyword`) and `ActiveStepTypes` (`KeywordList`) for external Temporal namespaces.
- Register both attributes for locally started Temporal and lite server environments.
- Update CLI documentation and validation errors.

## Testing

- Not run (not requested)