### PR TITLE
Use port 8802 for Dex Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ brew install superdurable/tap/dexcli
 dexcli dev --open
 ```
 
-Open Dex Web at [http://127.0.0.1:8901](http://127.0.0.1:8901). This starts
+Open Dex Web at [http://127.0.0.1:8802](http://127.0.0.1:8802). This starts
 local Temporal and its Web UI automatically. Connect to an existing Temporal
 server instead with `dexcli dev --temporal-address localhost:7233`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -21,7 +21,7 @@ The default endpoints are:
 
 | Service | Address |
 |---|---|
-| Dex Web | `http://127.0.0.1:8901` |
+| Dex Web | `http://127.0.0.1:8802` |
 | Dex Server | `127.0.0.1:8801` |
 | Temporal Web | `http://127.0.0.1:8233` |
 | Temporal | `127.0.0.1:7233` |
@@ -52,7 +52,7 @@ plaintext endpoints; Temporal Cloud authentication is not supported yet.
 ```text
 --bind-address string          local bind IP (default 127.0.0.1)
 --dex-port int                 Dex gRPC port (default 8801)
---web-port int                 Dex Web port (default 8901)
+--web-port int                 Dex Web port (default 8802)
 --temporal-address string      external Temporal host:port
 --temporal-namespace string    Temporal namespace (default default)
 --temporal-port int            local Temporal port (default 7233)

--- a/cli/internal/dev/config.go
+++ b/cli/internal/dev/config.go
@@ -33,7 +33,7 @@ import (
 const (
 	defaultBindAddress       = "127.0.0.1"
 	defaultDexPort           = 8801
-	defaultWebPort           = 8901
+	defaultWebPort           = 8802
 	defaultTemporalPort      = 7233
 	defaultTemporalUIPort    = 8233
 	defaultTemporalNamespace = "default"
@@ -44,7 +44,7 @@ type Config struct {
 	BindAddress string
 	// DexPort defaults to 8801 for the Dex gRPC server.
 	DexPort int
-	// WebPort defaults to 8901 for Dex Web.
+	// WebPort defaults to 8802 for Dex Web.
 	WebPort int
 	// TemporalAddress selects external Temporal when non-empty. Default is local mode.
 	TemporalAddress string

--- a/docs/design/plan/dexcli.md
+++ b/docs/design/plan/dexcli.md
@@ -20,7 +20,7 @@ dexcli dev
 Temporal Server  127.0.0.1:7233
 Temporal Web     http://127.0.0.1:8233
 Dex Server       127.0.0.1:8801
-Dex Web          http://127.0.0.1:8901
+Dex Web          http://127.0.0.1:8802
 ```
 
 用户也可以连接已有 Temporal：
@@ -54,7 +54,7 @@ dexcli dev --temporal-address localhost:7233
           ▼                 ▼                 ▼
  temporal server      Dex runtime       Go Web server
  start-dev             in-process         in-process
-   :7233                  :8801              :8901
+   :7233                  :8801              :8802
    :8233 UI                                  │
                                              ├── embedded SPA
                                              └── /api/* → Dex gRPC
@@ -70,7 +70,7 @@ External Temporal :7233
           │
        dexcli
           ├── Dex runtime :8801
-          └── Go Web server :8901
+          └── Go Web server :8802
 ```
 
 `dexcli` 只检查 external Temporal readiness 和必要的 Dex search attributes，不管理其生命周期。
@@ -206,7 +206,7 @@ Web config 至少包含：
 
 ```text
 BindAddress  127.0.0.1
-Port         8901
+Port         8802
 ```
 
 Server 提供：
@@ -267,7 +267,7 @@ dexcli dev [flags]
 
 --bind-address string          default 127.0.0.1
 --dex-port int                 default 8801
---web-port int                 default 8901
+--web-port int                 default 8802
 --temporal-address string      non-empty selects external Temporal
 --temporal-namespace string    default default
 --temporal-port int            default 7233; local mode only
@@ -359,7 +359,7 @@ Process manager 必须：
 ```text
 Dex development environment is ready
 
-Dex Web:       http://127.0.0.1:8901
+Dex Web:       http://127.0.0.1:8802
 Dex Server:    127.0.0.1:8801
 Temporal Web:  http://127.0.0.1:8233
 Temporal:      127.0.0.1:7233
@@ -370,7 +370,7 @@ Press Ctrl+C to stop.
 External Temporal mode 不伪造 Temporal Web URL：
 
 ```text
-Dex Web:       http://127.0.0.1:8901
+Dex Web:       http://127.0.0.1:8802
 Dex Server:    127.0.0.1:8801
 Temporal:      localhost:7233 (external)
 ```
@@ -378,7 +378,7 @@ Temporal:      localhost:7233 (external)
 错误必须指出 component 和修复方法，例如：
 
 ```text
-cannot start Dex Web: 127.0.0.1:8901 is already in use
+cannot start Dex Web: 127.0.0.1:8802 is already in use
 external Temporal is missing search attribute FlowType (Keyword)
 Temporal CLI was not found; reinstall dexcli with Homebrew
 ```
@@ -446,14 +446,14 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 - `--temporal-db-filename` 重启后保留 Temporal executions。
 - external mode 连接预先启动的 Temporal，不创建第二个 Temporal process。
 - 退出 external mode 后 external Temporal 仍然可用。
-- occupied 7233、8233、8801、8901 分别在部分启动前返回明确错误。
+- occupied 7233、8233、8801、8802 分别在部分启动前返回明确错误。
 - Temporal child 非预期退出会停止 Dex runtime 和 Web server，并返回非零状态。
 - SIGINT/SIGTERM 后所有 owned ports 可立即被下一次启动复用。
 - 在 PATH 中没有 `node`/`npm` 时，release binary 仍可提供完整 Dex Web。
 
 ### Browser E2E
 
-- 从 `http://127.0.0.1:8901` 搜索并进入 Flow Details。
+- 从 `http://127.0.0.1:8802` 搜索并进入 Flow Details。
 - 直接加载和刷新 `/flows/:flowId/:runId` 不产生 404。
 - Basic/Advanced query、pagination、long poll、Step Graph、Timeline 和 Reset 保持现有行为。
 - Dex Server 暂时不可用时展示可操作错误，恢复后能够重新加载。
@@ -475,7 +475,7 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 
 ## 14. UI/UX
 
-- Dex Web 的稳定默认入口是 `http://127.0.0.1:8901`。
+- Dex Web 的稳定默认入口是 `http://127.0.0.1:8802`。
 - `dexcli` 只在全部 services ready 后打印成功 banner。
 - `--open` 只打开 Dex Web，不自动打开 Temporal Web。
 - External Temporal 未提供 UI 地址时不显示猜测链接。
@@ -489,7 +489,7 @@ Temporal CLI was not found; reinstall dexcli with Homebrew
 1. `brew install dexcli` 是用户唯一的安装命令。
 2. `dexcli dev` 默认提供 Temporal、Temporal Web、Dex Server 和 Dex Web。
 3. `dexcli dev --temporal-address localhost:7233` 不启动或停止 local Temporal。
-4. Dex Web 默认运行在 `http://127.0.0.1:8901`。
+4. Dex Web 默认运行在 `http://127.0.0.1:8802`。
 5. Release runtime 不依赖 Node.js，不存在 Next.js API server。
 6. `cli` import `web` Go module，不复制 Web API implementation。
 7. 所有 server integration、Web API integration、browser E2E 和 packaging tests 通过。

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ Temporal/Cadence credentials and backend history never enter the browser.
 dexcli dev
 ```
 
-Open [http://127.0.0.1:8901](http://127.0.0.1:8901). No Node.js process runs in
+Open [http://127.0.0.1:8802](http://127.0.0.1:8802). No Node.js process runs in
 this mode.
 
 ## Frontend development
@@ -26,7 +26,7 @@ Terminal one starts the Go API bridge on port 8902:
 ./cli/dexcli dev --web-port 8902
 ```
 
-Terminal two starts Vite with hot reload on port 8901:
+Terminal two starts Vite with hot reload on port 8802:
 
 ```bash
 cd web

--- a/web/package.json
+++ b/web/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "vite --host 127.0.0.1 --port 8901",
+    "dev": "vite --host 127.0.0.1 --port 8802",
     "build": "vite build",
-    "preview": "vite preview --host 127.0.0.1 --port 8901",
+    "preview": "vite preview --host 127.0.0.1 --port 8802",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "check": "npm run typecheck && npm test"

--- a/web/server.go
+++ b/web/server.go
@@ -35,12 +35,12 @@ import (
 	"github.com/superdurable/dex/web/api"
 )
 
-const DefaultPort = 8901
+const DefaultPort = 8802
 
 type Config struct {
 	// BindAddress defaults to 127.0.0.1 and controls the HTTP bind IP.
 	BindAddress string
-	// Port defaults to 8901 and controls the HTTP bind port.
+	// Port defaults to 8802 and controls the HTTP bind port.
 	Port int
 }
 


### PR DESCRIPTION
## What changed

- change the standalone Go Web server default port from `8901` to `8802`
- change `dexcli dev` and Vite dev/preview defaults to `8802`
- update the root, CLI, Web, and design documentation

## Why

This aligns the local Dex ports as Dex Server `8801`, Dex Web `8802`, and worker `8803`.

## User impact

After upgrading, `dexcli dev` serves Dex Web at `http://127.0.0.1:8802` unless `--web-port` overrides it.

## Validation

- `make -C cli test`
- `GOWORK=off go test ./...` in `web/`
- `npm run check` in `web/` (TypeScript and 6 Vitest tests)
- `git diff --check`
