### PR TITLE
Enable integration tests against local Dex dev services

### DIFF
--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -182,6 +182,27 @@ this [issue](https://github.com/uber/cadence/issues/5076).
 * To run the whole suite for Cadence only `make cadenceIntegTests`
 * To run a specify test case or a test file, you can utilize the IDE or `go test` command.
 
+To reuse the Temporal and Dex Server managed by `dexcli dev`, run:
+
+```shell
+make temporalIntegTestsAgainstLocalDexDev
+```
+
+This target connects to Temporal at `127.0.0.1:7233` and Dex Server at
+`127.0.0.1:8801`. Override them with `temporalHostPort` and
+`dexServerAddress`. The tests register missing custom integration search
+attributes but never start or stop Temporal or Dex Server. Each test still
+starts its own worker on an ephemeral localhost port. Visibility search
+assertions are disabled because local Temporal uses SQLite instead of the CI
+visibility backend; indexed attribute read/write coverage remains enabled. The
+external client also supplies the suite's SYNC durability default when a start
+request omits it and preserves the suite's 12-second API wait cap.
+
+Tests requiring per-process Dex configuration—external storage, memo
+encryption, default headers, or disabled sticky cache—are skipped in this mode.
+They remain covered by `temporalIntegTests`, which starts an in-process Dex
+runtime for every test.
+
 CI integration tests are partitioned by top-level test name. Dynamic subtests run
 in the same partition as their parent. Reproduce a CI partition locally with:
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -178,6 +178,12 @@ integTests:
 temporalIntegTests:
 	$Q go test -v ./integ -timeout 20m -cadence=false
 
+dexServerAddress ?= 127.0.0.1:8801
+temporalHostPort ?= 127.0.0.1:7233
+
+temporalIntegTestsAgainstLocalDexDev:
+	$Q go test -v ./integ -timeout 20m -search=false -cadence=false -dexServerAddress=$(dexServerAddress) -temporalHostPort=$(temporalHostPort)
+
 cadenceIntegTests:
 	$Q go test -v ./integ -timeout 20m -temporal=false
 

--- a/server/integ/external_dex.go
+++ b/server/integ/external_dex.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2022-2026 Super Durable, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integ
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superdurable/dex/config"
+	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service"
+	temporalapi "github.com/superdurable/dex/service/client/temporal"
+	dexconverter "github.com/superdurable/dex/service/common/converter"
+	"github.com/superdurable/dex/service/common/ptr"
+	enumspb "go.temporal.io/api/enums/v1"
+	operatorservicepb "go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/sdk/client"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type temporalSearchAttribute struct {
+	name          string
+	attributeType enumspb.IndexedValueType
+}
+
+type externalDexFlowClient struct {
+	dexpb.FlowServiceClient
+	maxWaitSeconds int32
+}
+
+var localDexDevTestSearchAttributes = []temporalSearchAttribute{
+	{"CustomKeywordField", enumspb.INDEXED_VALUE_TYPE_KEYWORD},
+	{"CustomKeywordArrayField", enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST},
+	{"CustomIntField", enumspb.INDEXED_VALUE_TYPE_INT},
+	{"CustomBoolField", enumspb.INDEXED_VALUE_TYPE_BOOL},
+	{"CustomDoubleField", enumspb.INDEXED_VALUE_TYPE_DOUBLE},
+	{"CustomDatetimeField", enumspb.INDEXED_VALUE_TYPE_DATETIME},
+	{"CustomStringField", enumspb.INDEXED_VALUE_TYPE_TEXT},
+}
+
+func prepareExternalDex(
+	ctx context.Context,
+	temporalClient client.Client,
+) error {
+	if err := ensureTemporalSearchAttributes(ctx, temporalClient); err != nil {
+		return err
+	}
+	return waitForExternalDex(ctx)
+}
+
+func ensureTemporalSearchAttributes(ctx context.Context, temporalClient client.Client) error {
+	missingAttributes, err := getMissingTemporalSearchAttributes(ctx, temporalClient)
+	if err != nil {
+		return err
+	}
+	if len(missingAttributes) == 0 {
+		return nil
+	}
+	_, err = temporalClient.OperatorService().AddSearchAttributes(
+		ctx,
+		&operatorservicepb.AddSearchAttributesRequest{
+			Namespace:        testNamespace,
+			SearchAttributes: missingAttributes,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("register Temporal integration search attributes: %w", err)
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		missingAttributes, err = getMissingTemporalSearchAttributes(ctx, temporalClient)
+		if err != nil {
+			return err
+		}
+		if len(missingAttributes) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for Temporal integration search attributes: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func getMissingTemporalSearchAttributes(
+	ctx context.Context,
+	temporalClient client.Client,
+) (map[string]enumspb.IndexedValueType, error) {
+	response, err := temporalClient.OperatorService().ListSearchAttributes(
+		ctx,
+		&operatorservicepb.ListSearchAttributesRequest{Namespace: testNamespace},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list Temporal search attributes: %w", err)
+	}
+	missingAttributes := make(map[string]enumspb.IndexedValueType)
+	for _, requiredAttribute := range localDexDevTestSearchAttributes {
+		attributeType, exists := response.GetCustomAttributes()[requiredAttribute.name]
+		if !exists {
+			missingAttributes[requiredAttribute.name] = requiredAttribute.attributeType
+			continue
+		}
+		if attributeType != requiredAttribute.attributeType {
+			return nil, fmt.Errorf(
+				"Temporal search attribute %s must be %s, got %s",
+				requiredAttribute.name,
+				requiredAttribute.attributeType,
+				attributeType,
+			)
+		}
+	}
+	return missingAttributes, nil
+}
+
+func waitForExternalDex(ctx context.Context) (waitErr error) {
+	connection, err := newDexClientConnection(*dexServerAddress, config.DefaultGrpcMaxMessageBytes)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		waitErr = errors.Join(waitErr, connection.Close())
+	}()
+	healthClient := healthpb.NewHealthClient(connection)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		checkCtx, cancel := context.WithTimeout(ctx, time.Second)
+		response, checkErr := healthClient.Check(checkCtx, &healthpb.HealthCheckRequest{
+			Service: dexpb.FlowService_ServiceDesc.ServiceName,
+		})
+		cancel()
+		if checkErr == nil && response.GetStatus() == healthpb.HealthCheckResponse_SERVING {
+			return nil
+		}
+		if checkErr != nil {
+			lastErr = checkErr
+		} else {
+			lastErr = fmt.Errorf("Dex FlowService health status is %s", response.GetStatus())
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for Dex at %s: %w", *dexServerAddress, errors.Join(ctx.Err(), lastErr))
+		case <-ticker.C:
+		}
+	}
+}
+
+func connectToExternalDexService(t *testing.T, testConfig DexServiceTestConfig) *integRuntime {
+	t.Helper()
+	require.Equal(t, service.BackendTypeTemporal, testConfig.BackendType)
+	if unsupportedReason := externalDexUnsupportedReason(testConfig); unsupportedReason != "" {
+		t.Skipf("requires per-test in-process Dex configuration: %s", unsupportedReason)
+	}
+	cfg := createTestConfig(testConfig)
+	dataConverter := dexconverter.NewTemporalDataConverter()
+	temporalClient := createTemporalClient(t, dataConverter)
+	unifiedClient := temporalapi.NewTemporalClient(
+		temporalClient,
+		testNamespace,
+		dataConverter,
+		false,
+		&cfg.Api.QueryWorkflowFailedRetryPolicy,
+	)
+	t.Cleanup(unifiedClient.Close)
+	connection, err := newDexClientConnection(
+		*dexServerAddress,
+		cfg.Api.EffectiveGrpcMaxMessageBytes(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, connection.Close())
+	})
+	return &integRuntime{
+		FlowClient: &externalDexFlowClient{
+			FlowServiceClient: dexpb.NewFlowServiceClient(connection),
+			maxWaitSeconds:    int32(cfg.Api.EffectiveMaxWaitSeconds()),
+		},
+		UnifiedClient: unifiedClient,
+		defaultFlowConfig: &dexpb.FlowConfig{
+			ContinueAsNewThreshold: ptr.Any(int32(100)),
+			StepDurability: ptr.Any(
+				dexpb.StepDurability_STEP_DURABILITY_SYNC,
+			),
+		},
+		internalDumpCapture: &internalDumpHeaderCapture{},
+	}
+}
+
+func (client *externalDexFlowClient) StartFlow(
+	ctx context.Context,
+	request *dexpb.StartFlowRequest,
+	options ...grpc.CallOption,
+) (*dexpb.StartFlowResponse, error) {
+	if request.FlowStartOptions == nil {
+		request.FlowStartOptions = &dexpb.FlowStartOptions{}
+	}
+	if request.FlowStartOptions.FlowConfigOverride == nil {
+		request.FlowStartOptions.FlowConfigOverride = syncDurabilityConfig()
+	} else if request.FlowStartOptions.FlowConfigOverride.StepDurability == nil {
+		request.FlowStartOptions.FlowConfigOverride.StepDurability = ptr.Any(
+			dexpb.StepDurability_STEP_DURABILITY_SYNC,
+		)
+	}
+	return client.FlowServiceClient.StartFlow(ctx, request, options...)
+}
+
+func (client *externalDexFlowClient) WaitForFlow(
+	ctx context.Context,
+	request *dexpb.WaitForFlowRequest,
+	options ...grpc.CallOption,
+) (*dexpb.WaitForFlowResponse, error) {
+	if request.WaitTimeSeconds == 0 || request.WaitTimeSeconds > client.maxWaitSeconds {
+		request.WaitTimeSeconds = client.maxWaitSeconds
+	}
+	return client.FlowServiceClient.WaitForFlow(ctx, request, options...)
+}
+
+func (client *externalDexFlowClient) WaitForStepCompletion(
+	ctx context.Context,
+	request *dexpb.WaitForStepCompletionRequest,
+	options ...grpc.CallOption,
+) (*dexpb.WaitForStepCompletionResponse, error) {
+	request.WaitTimeSeconds = client.capPositiveWaitSeconds(request.WaitTimeSeconds)
+	return client.FlowServiceClient.WaitForStepCompletion(ctx, request, options...)
+}
+
+func (client *externalDexFlowClient) WaitForAttribute(
+	ctx context.Context,
+	request *dexpb.WaitForAttributeRequest,
+	options ...grpc.CallOption,
+) (*emptypb.Empty, error) {
+	request.WaitTimeSeconds = client.capPositiveWaitSeconds(request.WaitTimeSeconds)
+	return client.FlowServiceClient.WaitForAttribute(ctx, request, options...)
+}
+
+func (client *externalDexFlowClient) capPositiveWaitSeconds(waitSeconds int32) int32 {
+	if waitSeconds > client.maxWaitSeconds {
+		return client.maxWaitSeconds
+	}
+	return waitSeconds
+}
+
+func externalDexUnsupportedReason(testConfig DexServiceTestConfig) string {
+	if testConfig.MemoEncryption {
+		return "memo encryption"
+	}
+	if len(testConfig.DefaultHeaders) > 0 {
+		return "default headers"
+	}
+	if testConfig.S3TestThreshold > 0 || testConfig.LazyLoading != nil {
+		return "external storage"
+	}
+	if *disableStickyCache {
+		return "disabled sticky cache"
+	}
+	return ""
+}
+
+func newDexClientConnection(address string, maxMessageBytes int) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageBytes),
+			grpc.MaxCallSendMsgSize(maxMessageBytes),
+		),
+	)
+}

--- a/server/integ/flag.go
+++ b/server/integ/flag.go
@@ -38,6 +38,8 @@ var searchWaitTimeIntegTest = flag.Int("searchWaitMs", 2000, "the amount of time
 
 var temporalHostPort = flag.String("temporalHostPort", "", "temporal host port")
 
+var dexServerAddress = flag.String("dexServerAddress", "", "existing Dex gRPC address")
+
 var dependencyWaitSeconds = flag.Int("dependencyWaitSeconds", 60, "the number of seconds waiting for dependencies to be up(Cadence/Temporal)")
 
 var disableStickyCache = flag.Bool("disableStickyCache", false, "disable Temporal/Cadence sticky execution")

--- a/server/integ/main_test.go
+++ b/server/integ/main_test.go
@@ -59,6 +59,9 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Println("*temporalIntegTest, *cadenceIntegTest", *temporalIntegTest, *cadenceIntegTest)
+	if *dexServerAddress != "" && (!*temporalIntegTest || *cadenceIntegTest) {
+		log.Fatal("dexServerAddress requires Temporal-only integration tests")
+	}
 
 	if *temporalIntegTest {
 		var temporalClient client.Client
@@ -78,8 +81,21 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Fatalf("unable to connect to Temporal %v", err)
 		}
-		temporalClient.Close()
 		fmt.Println("connected to Temporal namespace")
+		if *dexServerAddress != "" {
+			dependencyCtx, cancelDependency := context.WithTimeout(
+				context.Background(),
+				time.Duration(*dependencyWaitSeconds)*time.Second,
+			)
+			err = prepareExternalDex(dependencyCtx, temporalClient)
+			cancelDependency()
+			if err != nil {
+				temporalClient.Close()
+				log.Fatalf("external Dex test setup failed: %v", err)
+			}
+			fmt.Println("connected to external Dex server", *dexServerAddress)
+		}
+		temporalClient.Close()
 		if *dependencyWaitSeconds > 0 {
 			time.Sleep(time.Second * 1) // see https://github.com/temporalio/temporal/issues/4160
 		}

--- a/server/integ/runtime.go
+++ b/server/integ/runtime.go
@@ -50,7 +50,6 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -61,6 +60,8 @@ type integRuntime struct {
 	FlowClient    dexpb.FlowServiceClient
 	UnifiedClient uclient.UnifiedClient
 	BlobStore     blobstore.BlobStore
+
+	defaultFlowConfig *dexpb.FlowConfig
 
 	internalDumpCapture *internalDumpHeaderCapture
 }
@@ -151,8 +152,16 @@ func withWorkerTarget(
 	return options
 }
 
-// startDexService starts API + interpreter against Temporal or Cadence and returns clients.
+// startDexService returns clients, starting API and interpreter unless an external Dex address is configured.
 func startDexService(t *testing.T, testConfig DexServiceTestConfig) *integRuntime {
+	t.Helper()
+	if *dexServerAddress != "" {
+		return connectToExternalDexService(t, testConfig)
+	}
+	return startInProcessDexService(t, testConfig)
+}
+
+func startInProcessDexService(t *testing.T, testConfig DexServiceTestConfig) *integRuntime {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -244,7 +253,10 @@ func startDexService(t *testing.T, testConfig DexServiceTestConfig) *integRuntim
 	}
 	startInterpreter(t, worker)
 	internalDumpCapture := &internalDumpHeaderCapture{}
-	runtime := &integRuntime{internalDumpCapture: internalDumpCapture}
+	runtime := &integRuntime{
+		defaultFlowConfig:   cfg.Interpreter.DefaultWorkflowConfig,
+		internalDumpCapture: internalDumpCapture,
+	}
 	previousDumpObserver := api.DumpFlowForContinueAsNewHeaderObserver
 	api.DumpFlowForContinueAsNewHeaderObserver = func(ctx context.Context) {
 		if incomingMetadata, ok := metadata.FromIncomingContext(ctx); ok {
@@ -266,13 +278,9 @@ func startDexService(t *testing.T, testConfig DexServiceTestConfig) *integRuntim
 		newInternalDumpHeaderCaptureInterceptor(internalDumpCapture),
 	)
 
-	connection, err := grpc.NewClient(
+	connection, err := newDexClientConnection(
 		listener.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(cfg.Api.EffectiveGrpcMaxMessageBytes()),
-			grpc.MaxCallSendMsgSize(cfg.Api.EffectiveGrpcMaxMessageBytes()),
-		),
+		cfg.Api.EffectiveGrpcMaxMessageBytes(),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -422,6 +430,16 @@ func asyncDurabilityConfig() *dexpb.FlowConfig {
 func syncDurabilityConfig() *dexpb.FlowConfig {
 	return &dexpb.FlowConfig{
 		StepDurability: ptr.Any(dexpb.StepDurability_STEP_DURABILITY_SYNC),
+	}
+}
+
+func copyFlowConfigForMutation(flowConfig *dexpb.FlowConfig) *dexpb.FlowConfig {
+	return &dexpb.FlowConfig{
+		ActiveStepSearchMode:         flowConfig.ActiveStepSearchMode,
+		ContinueAsNewThreshold:       flowConfig.ContinueAsNewThreshold,
+		ContinueAsNewPageSizeInBytes: flowConfig.ContinueAsNewPageSizeInBytes,
+		StepDurability:               flowConfig.StepDurability,
+		WorkerTarget:                 flowConfig.WorkerTarget,
 	}
 }
 

--- a/server/integ/signal_test.go
+++ b/server/integ/signal_test.go
@@ -110,9 +110,9 @@ func doTestSignalWorkflow(
 	var debugDump dexpb.DebugDumpResponse
 	err = unifiedClient.QueryWorkflow(ctx, &debugDump, flowId, "", service.DebugDumpQueryType)
 	require.NoError(t, err)
-	expectedConfig := proto.Clone(syncDurabilityConfig()).(*dexpb.FlowConfig)
+	expectedConfig := copyFlowConfigForMutation(runtime.defaultFlowConfig)
 	if flowConfig != nil {
-		expectedConfig = proto.Clone(flowConfig).(*dexpb.FlowConfig)
+		expectedConfig = copyFlowConfigForMutation(flowConfig)
 	}
 	expectedConfig.WorkerTarget = workerTarget
 	assertions.True(proto.Equal(expectedConfig, debugDump.GetConfig()))

--- a/server/integ/wait_for_attribute_test.go
+++ b/server/integ/wait_for_attribute_test.go
@@ -182,7 +182,7 @@ func doTestWaitForAttributeSuccess(t *testing.T) {
 			waitForAttributeKey,
 			expectedValue,
 		),
-		WaitTimeSeconds: 0,
+		WaitTimeSeconds: 10,
 		RequestId:       uuid.NewString(),
 	})
 	require.NoError(t, err)

--- a/server/integ/workflow/wf_state_options_search_attributes_loading/routers.go
+++ b/server/integ/workflow/wf_state_options_search_attributes_loading/routers.go
@@ -198,7 +198,7 @@ func upsertSearchAttributes() []*dexpb.AttributeWrite {
 	keywordArrayPayload, _ := json.Marshal([]string{"keyword1", "keyword2"})
 	return []*dexpb.AttributeWrite{
 		{
-			Key: "CustomKeywordField",
+			Key: "CustomKeywordArrayField",
 			Value: &dexpb.Value{
 				Kind: &dexpb.Value_ObjValue{
 					ObjValue: &dexpb.EncodedObject{

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -310,6 +310,25 @@ func (s *serviceImpl) WaitForStepCompletion(ctx context.Context, req *dexpb.Wait
 		if err == nil {
 			return &response, nil
 		}
+		if s.client.IsNotFoundError(err) {
+			completed, queryErr := s.isStepExecutionCompleted(
+				waitCtx,
+				req.GetFlowId(),
+				req.GetStepType(),
+				int32(stepExecutionNumber),
+			)
+			if queryErr == nil && completed {
+				return &response, nil
+			}
+			if queryErr != nil && !s.client.IsNotFoundError(queryErr) {
+				s.logger.Warn(
+					"failed to recover step completion after flow closed",
+					tag.WorkflowID(req.GetFlowId()),
+					tag.Error(queryErr),
+				)
+			}
+			return nil, s.handleError(err)
+		}
 		if updateType, ok := s.client.GetIfUpdateError(err, nil); !ok ||
 			updateType != dexpb.UpdateErrorType_UPDATE_ERROR_TYPE_CONTINUE_AS_NEW_PREEMPTED {
 			return nil, s.handleError(err)
@@ -326,6 +345,27 @@ func (s *serviceImpl) WaitForStepCompletion(ctx context.Context, req *dexpb.Wait
 			backoff *= 2
 		}
 	}
+}
+
+func (s *serviceImpl) isStepExecutionCompleted(
+	ctx context.Context,
+	flowID string,
+	stepType string,
+	stepExecutionNumber int32,
+) (bool, error) {
+	var completed bool
+	if err := s.client.QueryWorkflow(
+		ctx,
+		&completed,
+		flowID,
+		"",
+		service.IsStepExecutionCompletedQueryType,
+		stepType,
+		stepExecutionNumber,
+	); err != nil {
+		return false, err
+	}
+	return completed, nil
 }
 
 func (s *serviceImpl) WaitForAttribute(ctx context.Context, req *dexpb.WaitForAttributeRequest) (*emptypb.Empty, error) {

--- a/server/service/const.go
+++ b/server/service/const.go
@@ -31,11 +31,12 @@ const (
 
 	TaskQueue = "Interpreter_DEFAULT"
 
-	GetAttributesWorkflowQueryType   = "GetAttributes"
-	GetCurrentTimerInfosQueryType    = "GetCurrentTimerInfos"
-	ContinueAsNewDumpByPageQueryType = "ContinueAsNewDumpByPage"
-	DebugDumpQueryType               = "DebugNewDump"
-	PrepareRpcQueryType              = "PrepareRpcQueryType"
+	GetAttributesWorkflowQueryType    = "GetAttributes"
+	GetCurrentTimerInfosQueryType     = "GetCurrentTimerInfos"
+	ContinueAsNewDumpByPageQueryType  = "ContinueAsNewDumpByPage"
+	DebugDumpQueryType                = "DebugNewDump"
+	IsStepExecutionCompletedQueryType = "IsStepExecutionCompleted"
+	PrepareRpcQueryType               = "PrepareRpcQueryType"
 
 	ExecuteOptimisticLockingRpcUpdateType = "ExecuteOptimisticLockingRpcUpdate"
 	WaitForStepCompletionUpdateType       = "WaitForStepCompletion"

--- a/server/service/interpreter/queryHandler.go
+++ b/server/service/interpreter/queryHandler.go
@@ -36,6 +36,7 @@ func SetQueryHandlers(
 	persistenceManager *PersistenceManager,
 	channelStore *ChannelStore,
 	continueAsNewer *ContinueAsNewer,
+	stepExecutionCounter *StepExecutionCounter,
 	flowConfiger *config.FlowConfiger,
 	basicInfo service.BasicInfo,
 ) error {
@@ -60,6 +61,22 @@ func SetQueryHandlers(
 			ActiveStepExecutions:       continueAsNewer.GetActiveStepExecutionStates(),
 		}, nil
 	})
+	if err != nil {
+		return err
+	}
+	err = provider.SetQueryHandler(
+		ctx,
+		service.IsStepExecutionCompletedQueryType,
+		func(stepType string, stepExecutionNumber int32) (bool, error) {
+			if stepType == "" || stepExecutionNumber <= 0 {
+				return false, fmt.Errorf("step type and positive execution number are required")
+			}
+			return stepExecutionCounter.IsStepExecutionCompleted(
+				stepType,
+				stepExecutionNumber,
+			), nil
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/server/service/interpreter/workflowImpl.go
+++ b/server/service/interpreter/workflowImpl.go
@@ -226,6 +226,7 @@ func (i *Interpreter) StartEngineFlow(
 		persistenceManager,
 		channelStore,
 		continueAsNewer,
+		stepExecutionCounter,
 		flowConfiger,
 		basicInfo,
 	); err != nil {


### PR DESCRIPTION
## Summary

- Add a Make target for running Temporal integration tests against externally managed Temporal and Dex services.
- Register required Temporal search attributes and wait for local Dex health.
- Preserve test defaults and skip cases requiring per-process Dex configuration.
- Recover completed step waits after a workflow closes.

## Testing

- Not run (not requested)