### PR TITLE
Filter empty step completion outputs

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -145,14 +145,23 @@ type (
 		GrpcMaxMessageBytes int `yaml:"grpcMaxMessageBytes"`
 		// IncludeRPCInputOutputIntoHistory stores RPC input/output in Temporal/Cadence history for debugging. Default false.
 		IncludeRPCInputOutputIntoHistory bool `yaml:"includeRPCInputOutputIntoHistory"`
-		// QueryWorkflowFailedRetryPolicy retries failed Describe/Query calls and InvokeRPC after a run transition.
+		// QueryWorkflowFailedRetryPolicy retries failed Describe/Query calls against the backend.
 		QueryWorkflowFailedRetryPolicy QueryWorkflowFailedRetryPolicy `yaml:"queryWorkflowFailedRetryPolicy"`
+		// InvokeRPCContinuedAsNewErrorRetryPolicy retries InvokeRPC after ContinueAsNew. Default interval is 1 second and maximum attempts is 5.
+		InvokeRPCContinuedAsNewErrorRetryPolicy InvokeRPCContinuedAsNewErrorRetryPolicy `yaml:"invokeRPCContinuedAsNewErrorRetryPolicy"`
 	}
 
 	QueryWorkflowFailedRetryPolicy struct {
 		// InitialIntervalSeconds is the first backoff between query retries. Default 1.
 		InitialIntervalSeconds int `yaml:"initialIntervalSeconds"`
 		// MaximumAttempts is the max attempts including the first. Default 5.
+		MaximumAttempts int `yaml:"maximumAttempts"`
+	}
+
+	InvokeRPCContinuedAsNewErrorRetryPolicy struct {
+		// InitialIntervalSeconds is the delay between attempts. Non-positive values default to 1.
+		InitialIntervalSeconds int `yaml:"initialIntervalSeconds"`
+		// MaximumAttempts includes the initial attempt. Non-positive values default to 5.
 		MaximumAttempts int `yaml:"maximumAttempts"`
 	}
 
@@ -286,6 +295,18 @@ func (c ApiConfig) EffectiveMaxWaitSeconds() int64 {
 		return DefaultMaxWaitSeconds
 	}
 	return c.MaxWaitSeconds
+}
+
+// EffectiveInvokeRPCContinuedAsNewErrorRetryPolicy returns the configured policy with defaults.
+func (c ApiConfig) EffectiveInvokeRPCContinuedAsNewErrorRetryPolicy() InvokeRPCContinuedAsNewErrorRetryPolicy {
+	policy := c.InvokeRPCContinuedAsNewErrorRetryPolicy
+	if policy.InitialIntervalSeconds <= 0 {
+		policy.InitialIntervalSeconds = 1
+	}
+	if policy.MaximumAttempts <= 0 {
+		policy.MaximumAttempts = 5
+	}
+	return policy
 }
 
 // EffectiveLazyLoading returns LazyLoading, defaulting to true when omitted.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -145,7 +145,7 @@ type (
 		GrpcMaxMessageBytes int `yaml:"grpcMaxMessageBytes"`
 		// IncludeRPCInputOutputIntoHistory stores RPC input/output in Temporal/Cadence history for debugging. Default false.
 		IncludeRPCInputOutputIntoHistory bool `yaml:"includeRPCInputOutputIntoHistory"`
-		// QueryWorkflowFailedRetryPolicy retries failed Describe/Query calls against the backend.
+		// QueryWorkflowFailedRetryPolicy retries failed Describe/Query calls and InvokeRPC after a run transition.
 		QueryWorkflowFailedRetryPolicy QueryWorkflowFailedRetryPolicy `yaml:"queryWorkflowFailedRetryPolicy"`
 	}
 

--- a/server/config/config_template.yaml
+++ b/server/config/config_template.yaml
@@ -5,6 +5,9 @@ api:
   queryWorkflowFailedRetryPolicy:
     initialIntervalSeconds: 1
     maximumAttempts: 5
+  invokeRPCContinuedAsNewErrorRetryPolicy:
+    initialIntervalSeconds: 1
+    maximumAttempts: 5
 worker:
   # Refresh individual endpoints behind headless WorkerService DNS.
   headlessAddressRefreshInterval: 60s

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -7,6 +7,9 @@ api:
   queryWorkflowFailedRetryPolicy:
     initialIntervalSeconds: 1
     maximumAttempts: 5
+  invokeRPCContinuedAsNewErrorRetryPolicy:
+    initialIntervalSeconds: 1
+    maximumAttempts: 5
 interpreter:
   temporal:
     hostPort: localhost:7233

--- a/server/config/development_cadence.yaml
+++ b/server/config/development_cadence.yaml
@@ -3,6 +3,9 @@ api:
   queryWorkflowFailedRetryPolicy:
     initialIntervalSeconds: 1
     maximumAttempts: 5
+  invokeRPCContinuedAsNewErrorRetryPolicy:
+    initialIntervalSeconds: 1
+    maximumAttempts: 5
 interpreter:
   #  interpreterActivityConfig:
   #  disableSystemSearchAttributes: true # (deprecated) set to true if you don't have advanced visibility in Cadence, see more https://github.com/uber/cadence/issues/5085

--- a/server/integ/command_thread_completion_test.go
+++ b/server/integ/command_thread_completion_test.go
@@ -200,7 +200,8 @@ func doTestCommandThreadCompletion(
 	}()
 
 	response, err := flowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{
-		FlowId: flowId,
+		FlowId:       flowId,
+		NeedsResults: true,
 	})
 	require.NoError(t, err)
 
@@ -219,6 +220,7 @@ func doTestCommandThreadCompletion(
 	}, history, "Command thread completion test failed - state execution history mismatch: %v", history)
 
 	assertions.Equal(dexpb.FlowStatus_FLOW_STATUS_COMPLETED, response.GetFlowStatus())
+	assertions.Empty(response.GetResults())
 
 	s1TimerFired, ok := data["s1_timer_fired"].(bool)
 	assertions.True(ok)

--- a/server/integ/command_thread_completion_test.go
+++ b/server/integ/command_thread_completion_test.go
@@ -98,6 +98,7 @@ func doTestAnyCommandCompleted(t *testing.T, backendType service.BackendType) {
 		FlowTimeoutSeconds: 60,
 
 		StartStepType: command_thread_completion.StateAnyCmd,
+		StepInput:     nullValue(),
 		FlowStartOptions: withWorkerTarget(&dexpb.FlowStartOptions{
 			FlowConfigOverride: &dexpb.FlowConfig{
 				ContinueAsNewThreshold: ptr.Any(int32(1)),
@@ -126,6 +127,7 @@ func doTestAnyCommandCompleted(t *testing.T, backendType service.BackendType) {
 
 	response, err := flowClient.WaitForFlow(ctx, &dexpb.WaitForFlowRequest{
 		FlowId:          flowId,
+		NeedsResults:    true,
 		WaitTimeSeconds: 20,
 	})
 	if err != nil {
@@ -149,6 +151,7 @@ func doTestAnyCommandCompleted(t *testing.T, backendType service.BackendType) {
 	}, history, "State execution history mismatch: %v", history)
 
 	assertions.Equal(dexpb.FlowStatus_FLOW_STATUS_COMPLETED, response.GetFlowStatus())
+	assertions.Empty(response.GetResults())
 	signalReceived, ok := data["any_cmd_signal_received"].(bool)
 	assertions.True(ok, "any_cmd_signal_received data should be present")
 	assertions.True(signalReceived)

--- a/server/integ/workflow/command_thread_completion/routers.go
+++ b/server/integ/workflow/command_thread_completion/routers.go
@@ -282,7 +282,7 @@ func (h *handler) InvokeExecuteMethod(
 
 		return &dexpb.InvokeExecuteMethodResponse{
 			StepDecision: &dexpb.StepDecision{
-				CloseDecision: common.GracefulCompleteDecision(nil),
+				CloseDecision: common.GracefulCompleteDecision(request.GetStepInput()),
 			},
 		}, nil
 	case StateAnyCmd:
@@ -318,7 +318,7 @@ func (h *handler) InvokeExecuteMethod(
 		return &dexpb.InvokeExecuteMethodResponse{
 			StepDecision: &dexpb.StepDecision{
 				NextSteps: []*dexpb.StepMovement{
-					{StepType: State3},
+					{StepType: State3, StepInput: request.GetStepInput()},
 				},
 			},
 		}, nil

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -891,6 +891,10 @@ func (s *serviceImpl) InvokeRPC(
 	if err := workerclient.RejectWorkerBlobIDs(req.GetInput()); err != nil {
 		return nil, makeInvalidRequestError(err.Error())
 	}
+	if len(req.GetLockAttributeKeys()) > 0 &&
+		s.client.GetBackendType() == service.BackendTypeCadence {
+		return nil, status.Errorf(codes.Unimplemented, "locking RPC requires Temporal synchronous update")
+	}
 	runID := req.GetRunId()
 	if runID == "" {
 		description, err := s.client.DescribeWorkflowExecution(ctx, req.GetFlowId(), "", nil)
@@ -900,16 +904,15 @@ func (s *serviceImpl) InvokeRPC(
 		runID = description.RunId
 	}
 
-	retryPolicy := config.QueryWorkflowFailedRetryPolicyWithDefaults(
-		&s.apiCfg.QueryWorkflowFailedRetryPolicy,
-	)
+	retryPolicy := s.apiCfg.EffectiveInvokeRPCContinuedAsNewErrorRetryPolicy()
 	for attempt := 1; ; attempt++ {
 		response, err := s.doInvokeRPC(ctx, req, runID)
 		if err == nil {
 			return response, nil
 		}
-		if req.GetRunId() != "" || attempt >= retryPolicy.MaximumAttempts {
-			return nil, err
+		if req.GetRunId() != "" || !s.client.IsNotFoundError(err) ||
+			attempt >= retryPolicy.MaximumAttempts {
+			return nil, s.handleInvokeRPCError(err)
 		}
 		description, describeErr := s.client.DescribeWorkflowExecution(
 			ctx,
@@ -923,10 +926,10 @@ func (s *serviceImpl) InvokeRPC(
 				tag.WorkflowID(req.GetFlowId()),
 				tag.Error(describeErr),
 			)
-			return nil, err
+			return nil, s.handleInvokeRPCError(err)
 		}
 		if description.RunId == runID {
-			return nil, err
+			return nil, s.handleInvokeRPCError(err)
 		}
 		runID = description.RunId
 		if retryErr := waitForCANRetry(
@@ -957,7 +960,7 @@ func (s *serviceImpl) doInvokeRPC(
 		service.PrepareRpcQueryType,
 		&dexpb.PrepareRpcQueryRequest{},
 	); err != nil {
-		return nil, s.handleError(err)
+		return nil, err
 	}
 	workerResponse, err := rpc.InvokeWorkerRpc(
 		ctx,
@@ -970,10 +973,7 @@ func (s *serviceImpl) doInvokeRPC(
 		s.extStore,
 	)
 	if err != nil {
-		if mapped, ok := serviceerrors.WorkerAPIFailure(err); ok {
-			return nil, mapped.ToGRPCError()
-		}
-		return nil, s.handleError(err)
+		return nil, err
 	}
 	decision := workerResponse.GetStepDecision()
 	if len(workerResponse.GetUpsertAttributes()) > 0 ||
@@ -998,10 +998,17 @@ func (s *serviceImpl) doInvokeRPC(
 			service.ExecuteRpcSignalChannelName,
 			signalRequest,
 		); err != nil {
-			return nil, s.handleError(err)
+			return nil, err
 		}
 	}
 	return &dexpb.InvokeRPCResponse{Output: workerResponse.GetOutput()}, nil
+}
+
+func (s *serviceImpl) handleInvokeRPCError(err error) error {
+	if mapped, ok := serviceerrors.WorkerAPIFailure(err); ok {
+		return mapped.ToGRPCError()
+	}
+	return s.handleError(err)
 }
 
 func (s *serviceImpl) handleRpcBySynchronousUpdate(
@@ -1009,9 +1016,6 @@ func (s *serviceImpl) handleRpcBySynchronousUpdate(
 	req *dexpb.InvokeRPCRequest,
 	runID string,
 ) (*dexpb.InvokeRPCResponse, error) {
-	if s.client.GetBackendType() == service.BackendTypeCadence {
-		return nil, status.Errorf(codes.Unimplemented, "locking RPC requires Temporal synchronous update")
-	}
 	var result dexpb.InvokeRpcUpdateResult
 	if err := s.client.SynchronousUpdateWorkflow(
 		ctx,
@@ -1022,10 +1026,10 @@ func (s *serviceImpl) handleRpcBySynchronousUpdate(
 		service.ExecuteOptimisticLockingRpcUpdateType,
 		req,
 	); err != nil {
-		return nil, s.handleError(err)
+		return nil, err
 	}
 	if result.GetResponse() == nil {
-		return nil, serviceerrors.Internal("locking RPC returned no response").ToGRPCError()
+		return nil, fmt.Errorf("locking RPC returned no response")
 	}
 	return result.GetResponse(), nil
 }

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -49,10 +49,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const (
-	defaultHistoryPageSize           = 100
-	invokeRpcCANRetryMaximumAttempts = 6
-)
+const defaultHistoryPageSize = 100
 
 type serviceImpl struct {
 	client         uclient.UnifiedClient
@@ -894,18 +891,78 @@ func (s *serviceImpl) InvokeRPC(
 	if err := workerclient.RejectWorkerBlobIDs(req.GetInput()); err != nil {
 		return nil, makeInvalidRequestError(err.Error())
 	}
-	if len(req.GetLockAttributeKeys()) > 0 {
-		return s.handleRpcBySynchronousUpdate(ctx, req)
+	runID := req.GetRunId()
+	if runID == "" {
+		description, err := s.client.DescribeWorkflowExecution(ctx, req.GetFlowId(), "", nil)
+		if err != nil {
+			return nil, s.handleError(err)
+		}
+		runID = description.RunId
 	}
 
-	preparation, err := s.queryRpcPreparation(ctx, req)
-	if err != nil {
+	retryPolicy := config.QueryWorkflowFailedRetryPolicyWithDefaults(
+		&s.apiCfg.QueryWorkflowFailedRetryPolicy,
+	)
+	for attempt := 1; ; attempt++ {
+		response, err := s.doInvokeRPC(ctx, req, runID)
+		if err == nil {
+			return response, nil
+		}
+		if req.GetRunId() != "" || attempt >= retryPolicy.MaximumAttempts {
+			return nil, err
+		}
+		description, describeErr := s.client.DescribeWorkflowExecution(
+			ctx,
+			req.GetFlowId(),
+			"",
+			nil,
+		)
+		if describeErr != nil {
+			s.logger.Warn(
+				"failed to resolve current run after RPC error",
+				tag.WorkflowID(req.GetFlowId()),
+				tag.Error(describeErr),
+			)
+			return nil, err
+		}
+		if description.RunId == runID {
+			return nil, err
+		}
+		runID = description.RunId
+		if retryErr := waitForCANRetry(
+			ctx,
+			time.Time{},
+			time.Duration(retryPolicy.InitialIntervalSeconds)*time.Second,
+		); retryErr != nil {
+			return nil, s.handleError(retryErr)
+		}
+	}
+}
+
+func (s *serviceImpl) doInvokeRPC(
+	ctx context.Context,
+	req *dexpb.InvokeRPCRequest,
+	runID string,
+) (*dexpb.InvokeRPCResponse, error) {
+	if len(req.GetLockAttributeKeys()) > 0 {
+		return s.handleRpcBySynchronousUpdate(ctx, req, runID)
+	}
+
+	var preparation dexpb.PrepareRpcQueryResponse
+	if err := s.client.QueryWorkflow(
+		ctx,
+		&preparation,
+		req.GetFlowId(),
+		runID,
+		service.PrepareRpcQueryType,
+		&dexpb.PrepareRpcQueryRequest{},
+	); err != nil {
 		return nil, s.handleError(err)
 	}
 	workerResponse, err := rpc.InvokeWorkerRpc(
 		ctx,
 		s.workerPool,
-		preparation,
+		&preparation,
 		req,
 		s.apiCfg.EffectiveMaxWaitSeconds(),
 		s.store,
@@ -937,7 +994,7 @@ func (s *serviceImpl) InvokeRPC(
 		if err := s.client.SignalWorkflow(
 			ctx,
 			req.GetFlowId(),
-			req.GetRunId(),
+			runID,
 			service.ExecuteRpcSignalChannelName,
 			signalRequest,
 		); err != nil {
@@ -947,40 +1004,10 @@ func (s *serviceImpl) InvokeRPC(
 	return &dexpb.InvokeRPCResponse{Output: workerResponse.GetOutput()}, nil
 }
 
-func (s *serviceImpl) queryRpcPreparation(
-	ctx context.Context,
-	req *dexpb.InvokeRPCRequest,
-) (*dexpb.PrepareRpcQueryResponse, error) {
-	backoff := 25 * time.Millisecond
-	for attempt := 1; ; attempt++ {
-		preparation := &dexpb.PrepareRpcQueryResponse{}
-		err := s.client.QueryWorkflow(
-			ctx,
-			preparation,
-			req.GetFlowId(),
-			req.GetRunId(),
-			service.PrepareRpcQueryType,
-			&dexpb.PrepareRpcQueryRequest{},
-		)
-		if err == nil {
-			return preparation, nil
-		}
-		if req.GetRunId() != "" || !s.client.IsNotFoundError(err) ||
-			attempt >= invokeRpcCANRetryMaximumAttempts {
-			return nil, err
-		}
-		if err := waitForCANRetry(ctx, time.Time{}, backoff); err != nil {
-			return nil, err
-		}
-		if backoff < time.Second {
-			backoff *= 2
-		}
-	}
-}
-
 func (s *serviceImpl) handleRpcBySynchronousUpdate(
 	ctx context.Context,
 	req *dexpb.InvokeRPCRequest,
+	runID string,
 ) (*dexpb.InvokeRPCResponse, error) {
 	if s.client.GetBackendType() == service.BackendTypeCadence {
 		return nil, status.Errorf(codes.Unimplemented, "locking RPC requires Temporal synchronous update")
@@ -990,7 +1017,7 @@ func (s *serviceImpl) handleRpcBySynchronousUpdate(
 		ctx,
 		&result,
 		req.GetFlowId(),
-		req.GetRunId(),
+		runID,
 		req.GetRequestId(),
 		service.ExecuteOptimisticLockingRpcUpdateType,
 		req,

--- a/server/service/api/service.go
+++ b/server/service/api/service.go
@@ -49,7 +49,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const defaultHistoryPageSize = 100
+const (
+	defaultHistoryPageSize           = 100
+	invokeRpcCANRetryMaximumAttempts = 6
+)
 
 type serviceImpl struct {
 	client         uclient.UnifiedClient
@@ -895,21 +898,14 @@ func (s *serviceImpl) InvokeRPC(
 		return s.handleRpcBySynchronousUpdate(ctx, req)
 	}
 
-	var preparation dexpb.PrepareRpcQueryResponse
-	if err := s.client.QueryWorkflow(
-		ctx,
-		&preparation,
-		req.GetFlowId(),
-		req.GetRunId(),
-		service.PrepareRpcQueryType,
-		&dexpb.PrepareRpcQueryRequest{},
-	); err != nil {
+	preparation, err := s.queryRpcPreparation(ctx, req)
+	if err != nil {
 		return nil, s.handleError(err)
 	}
 	workerResponse, err := rpc.InvokeWorkerRpc(
 		ctx,
 		s.workerPool,
-		&preparation,
+		preparation,
 		req,
 		s.apiCfg.EffectiveMaxWaitSeconds(),
 		s.store,
@@ -949,6 +945,37 @@ func (s *serviceImpl) InvokeRPC(
 		}
 	}
 	return &dexpb.InvokeRPCResponse{Output: workerResponse.GetOutput()}, nil
+}
+
+func (s *serviceImpl) queryRpcPreparation(
+	ctx context.Context,
+	req *dexpb.InvokeRPCRequest,
+) (*dexpb.PrepareRpcQueryResponse, error) {
+	backoff := 25 * time.Millisecond
+	for attempt := 1; ; attempt++ {
+		preparation := &dexpb.PrepareRpcQueryResponse{}
+		err := s.client.QueryWorkflow(
+			ctx,
+			preparation,
+			req.GetFlowId(),
+			req.GetRunId(),
+			service.PrepareRpcQueryType,
+			&dexpb.PrepareRpcQueryRequest{},
+		)
+		if err == nil {
+			return preparation, nil
+		}
+		if req.GetRunId() != "" || !s.client.IsNotFoundError(err) ||
+			attempt >= invokeRpcCANRetryMaximumAttempts {
+			return nil, err
+		}
+		if err := waitForCANRetry(ctx, time.Time{}, backoff); err != nil {
+			return nil, err
+		}
+		if backoff < time.Second {
+			backoff *= 2
+		}
+	}
 }
 
 func (s *serviceImpl) handleRpcBySynchronousUpdate(

--- a/server/service/interpreter/outputCollector.go
+++ b/server/service/interpreter/outputCollector.go
@@ -20,7 +20,10 @@
 
 package interpreter
 
-import "github.com/superdurable/dex/gen/dexpb"
+import (
+	"github.com/superdurable/dex/gen/dexpb"
+	"github.com/superdurable/dex/service/common/utils"
+)
 
 type OutputCollector struct {
 	outputs []*dexpb.StepCompletionOutput
@@ -37,7 +40,11 @@ func NewOutputCollector(initOutputs []*dexpb.StepCompletionOutput) *OutputCollec
 func (o *OutputCollector) Add(
 	output *dexpb.StepCompletionOutput,
 ) {
-	if output == nil || output.GetCompletedStepOutput().GetKind() == nil {
+	if output == nil {
+		return
+	}
+	completedStepOutput := output.GetCompletedStepOutput()
+	if completedStepOutput.GetKind() == nil || utils.IsNullValue(completedStepOutput) {
 		return
 	}
 	o.outputs = append(o.outputs, output)

--- a/server/service/interpreter/outputCollector.go
+++ b/server/service/interpreter/outputCollector.go
@@ -27,17 +27,19 @@ type OutputCollector struct {
 }
 
 func NewOutputCollector(initOutputs []*dexpb.StepCompletionOutput) *OutputCollector {
-	if initOutputs == nil {
-		initOutputs = []*dexpb.StepCompletionOutput{}
+	collector := &OutputCollector{}
+	for _, output := range initOutputs {
+		collector.Add(output)
 	}
-	return &OutputCollector{
-		outputs: initOutputs,
-	}
+	return collector
 }
 
 func (o *OutputCollector) Add(
 	output *dexpb.StepCompletionOutput,
 ) {
+	if output == nil || output.GetCompletedStepOutput().GetKind() == nil {
+		return
+	}
 	o.outputs = append(o.outputs, output)
 }
 


### PR DESCRIPTION
## Summary

- skip collecting step completion entries whose output is nil, structurally empty, or explicitly null
- apply the same filtering when restoring collected outputs after ContinueAsNew
- assert that dead-end, empty, and null graceful-completion paths return no results

## Why

Graceful completions without a user-visible output created empty `StepCompletionOutput` entries. These entries accumulated in workflow state and were carried across ContinueAsNew.

## Impact

Absent, structurally empty, and explicit null outputs are omitted. Explicit zero values, empty strings, `false`, and other non-null protobuf kinds remain valid results.

## Validation

- `make -C server unitTests`
- `make -C server cadenceIntegTests GOFLAGS='-run=^(TestCommandThreadCompletionCadence|TestAnyCommandCompletedCadence)$'`
- `make copyright-check`
- `git diff --check`
