### PR TITLE
Improve Dex Web semantic flow views

### DIFF
--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -198,6 +198,19 @@ visibility backend; indexed attribute read/write coverage remains enabled. The
 external client also supplies the suite's SYNC durability default when a start
 request omits it and preserves the suite's 12-second API wait cap.
 
+The target excludes top-level tests whose names contain `ContinueAsNew` by
+default:
+
+```shell
+make temporalIntegTestsAgainstLocalDexDev \
+  dexServerAddress=127.0.0.1:18801 \
+  temporalHostPort=127.0.0.1:7233
+```
+
+Set `skipContinueAsNewTests=false` to run every top-level test. When filtering,
+the target lists the tests and runs those whose names do not contain
+`ContinueAsNew`.
+
 Tests requiring per-process Dex configuration—external storage, memo
 encryption, default headers, or disabled sticky cache—are skipped in this mode.
 They remain covered by `temporalIntegTests`, which starts an in-process Dex

--- a/server/Makefile
+++ b/server/Makefile
@@ -180,9 +180,15 @@ temporalIntegTests:
 
 dexServerAddress ?= 127.0.0.1:8801
 temporalHostPort ?= 127.0.0.1:7233
+skipContinueAsNewTests ?= true
 
 temporalIntegTestsAgainstLocalDexDev:
-	$Q go test -v ./integ -timeout 20m -search=false -cadence=false -dexServerAddress=$(dexServerAddress) -temporalHostPort=$(temporalHostPort)
+	$Q set -e; \
+		test_run_pattern='.'; \
+		if [ "$(skipContinueAsNewTests)" = "true" ]; then \
+			test_run_pattern="$$(go test -v ./integ -list '^Test' -temporal=false -cadence=false -dependencyWaitSeconds=0 | awk '/^Test/ && $$0 !~ /ContinueAsNew/ { tests = tests separator $$0; separator = "|" } END { print "^(" tests ")$$" }')"; \
+		fi; \
+		go test -v ./integ -timeout 20m -run "$$test_run_pattern" -search=false -cadence=false -dexServerAddress=$(dexServerAddress) -temporalHostPort=$(temporalHostPort)
 
 cadenceIntegTests:
 	$Q go test -v ./integ -timeout 20m -temporal=false

--- a/web/README.md
+++ b/web/README.md
@@ -58,3 +58,6 @@ preferences.
 The Run page provides Overview, Step graph, Timeline, active/waiting state,
 attributes, timers, queued steps, channels, completed outputs, and reset.
 Continued runs link to their previous run from Timeline and Step graph.
+Step graph nodes separate WaitFor and Execute with distinct colors, channel names, condition icons, and individual event details.
+Timeline and Step graph share structured event details for flow, step method, RPC,
+and channel events. A Raw JSON tab preserves the complete server payload.

--- a/web/README.md
+++ b/web/README.md
@@ -57,3 +57,4 @@ preferences.
 
 The Run page provides Overview, Step graph, Timeline, active/waiting state,
 attributes, timers, queued steps, channels, completed outputs, and reset.
+Continued runs link to their previous run from Timeline and Step graph.

--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -103,6 +103,13 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
 
   useEffect(() => {
     let active = true;
+    setSummary(null);
+    setHistory([]);
+    setState(null);
+    setNextPageToken('');
+    setNextInternalEventId(0);
+    setSelectedEvent(null);
+    setError('');
     setLoading(true);
     void refresh().finally(() => {
       if (active) setLoading(false);
@@ -234,6 +241,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
           )}
           {tab === 'steps' && (
             <StepGraph
+              flowId={flowId}
               events={history}
               state={state}
               selectedEvent={selectedEvent}
@@ -242,6 +250,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
           )}
           {tab === 'timeline' && (
             <Timeline
+              flowId={flowId}
               events={history}
               selectedEvent={selectedEvent}
               onSelectEvent={setSelectedEvent}

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -20,7 +20,7 @@ type Field = [label: string, value: unknown];
 const eventTitles: Record<FlowHistoryEvent['type'], string> = {
   FlowStartedOrContinued: 'Flow started',
   FlowClosed: 'Flow closed',
-  StepWaitForCompleted: 'WaitFor started',
+  StepWaitForCompleted: 'WaitForCondition started',
   StepWaitForFailed: 'WaitFor failed',
   StepExecuteCompleted: 'Execute completed',
   StepExecuteFailed: 'Execute failed',

--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -1,0 +1,613 @@
+'use client';
+
+import { useState } from 'react';
+import type { FlowHistoryEvent } from '@/lib/types';
+import {
+  activeStepSearchModeLabel,
+  closeDecisionTypeLabel,
+  conditionStatusLabel,
+  durabilityLabel,
+  executeFailurePolicyLabel,
+  flowErrorTypeLabel,
+  flowStatusLabel,
+  waitForFailurePolicyLabel,
+  waitingConditionTypeLabel,
+} from '@/lib/semantic';
+
+type Data = Record<string, unknown>;
+type Field = [label: string, value: unknown];
+
+const eventTitles: Record<FlowHistoryEvent['type'], string> = {
+  FlowStartedOrContinued: 'Flow started',
+  FlowClosed: 'Flow closed',
+  StepWaitForCompleted: 'WaitFor started',
+  StepWaitForFailed: 'WaitFor failed',
+  StepExecuteCompleted: 'Execute completed',
+  StepExecuteFailed: 'Execute failed',
+  RpcExecutionCompleted: 'RPC completed',
+  ChannelExternalPublish: 'Channel published',
+};
+
+export function eventTitle(event: FlowHistoryEvent): string {
+  if (event.type === 'FlowStartedOrContinued' && hasData(asData(event.payload.continuedStart))) {
+    return 'Flow continued';
+  }
+  return eventTitles[event.type];
+}
+
+function asData(value: unknown): Data {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Data : {};
+}
+
+function asDataArray(value: unknown): Data[] {
+  return Array.isArray(value) ? value.map(asData) : [];
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function hasData(value: Data): boolean {
+  return Object.keys(value).length > 0;
+}
+
+function isPresent(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== '';
+}
+
+function decodedValue(value: unknown): unknown {
+  const message = asData(value);
+  if ('stringValue' in message) return message.stringValue;
+  if ('intValue' in message) return message.intValue;
+  if ('doubleValue' in message) return message.doubleValue;
+  if ('boolValue' in message) return message.boolValue;
+  if ('nullValue' in message) return null;
+  const object = asData(message.objValue);
+  if (typeof object.payload !== 'string') return value;
+  try {
+    const bytes = Uint8Array.from(atob(object.payload), (character) => character.charCodeAt(0));
+    const decoded = new TextDecoder().decode(bytes);
+    if (object.encoding === 'json') {
+      try {
+        return JSON.parse(decoded) as unknown;
+      } catch {
+        return decoded;
+      }
+    }
+    return decoded;
+  } catch {
+    return value;
+  }
+}
+
+function displayScalar(value: unknown): string {
+  if (value === undefined || value === null || value === '') return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  return JSON.stringify(value);
+}
+
+function DetailSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="semantic-section">
+      <h4>{title}</h4>
+      {children}
+    </section>
+  );
+}
+
+function Fields({ values }: { values: Field[] }) {
+  const visible = values.filter(([, value]) => isPresent(value));
+  if (visible.length === 0) return null;
+  return (
+    <dl className="semantic-fields">
+      {visible.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{displayScalar(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ValueBlock({ label, value }: { label: string; value: unknown }) {
+  if (!isPresent(value)) return null;
+  const decoded = decodedValue(value);
+  return (
+    <div className="semantic-value">
+      <span>{label}</span>
+      {decoded && typeof decoded === 'object'
+        ? <pre>{JSON.stringify(decoded, null, 2)}</pre>
+        : <code>{displayScalar(decoded)}</code>}
+    </div>
+  );
+}
+
+function KeyValues({ values, emptyLabel }: { values: unknown; emptyLabel?: string }) {
+  const entries = asDataArray(values);
+  if (entries.length === 0) return emptyLabel ? <p className="muted">{emptyLabel}</p> : null;
+  return (
+    <div className="semantic-records">
+      {entries.map((entry, index) => (
+        <div className="semantic-record" key={`${String(entry.key)}-${index}`}>
+          <strong>{displayScalar(entry.key)}</strong>
+          <ValueBlock label="Value" value={entry.value} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ChannelMessages({ values }: { values: unknown }) {
+  const messages = asDataArray(values);
+  if (messages.length === 0) return null;
+  return (
+    <div className="semantic-records">
+      {messages.map((message, index) => (
+        <div className="semantic-record channel-record" key={`${String(message.channelName)}-${index}`}>
+          <strong><ChannelIcon />{displayScalar(message.channelName)}</strong>
+          <ValueBlock label="Message" value={message.value} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ChannelIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16">
+      <circle cx="4" cy="4" r="1.7" />
+      <circle cx="12" cy="8" r="1.7" />
+      <circle cx="4" cy="12" r="1.7" />
+      <path d="M5.7 4.7 10.3 7M5.7 11.3 10.3 9" />
+    </svg>
+  );
+}
+
+function StepOutputs({ values }: { values: unknown }) {
+  const outputs = asDataArray(values);
+  if (outputs.length === 0) return null;
+  return (
+    <div className="semantic-records">
+      {outputs.map((output, index) => (
+        <div className="semantic-record" key={`${String(output.completedStepExecutionId)}-${index}`}>
+          <Fields values={[
+            ['Step', output.completedStepType],
+            ['Execution ID', output.completedStepExecutionId],
+          ]} />
+          <ValueBlock label="Output" value={output.completedStepOutput} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StepOptionsView({ value }: { value: unknown }) {
+  const options = asData(value);
+  if (!hasData(options)) return null;
+  return (
+    <div className="semantic-subsection">
+      <h5>Options</h5>
+      <Fields values={[
+        ['WaitFor timeout', seconds(options.waitForTimeoutSeconds)],
+        ['Execute timeout', seconds(options.executeTimeoutSeconds)],
+        ['Skip WaitFor', options.skipWaitFor],
+        ['WaitFor durability', isPresent(options.waitForDurabilityOverride) ? durabilityLabel(options.waitForDurabilityOverride) : undefined],
+        ['Execute durability', isPresent(options.executeDurabilityOverride) ? durabilityLabel(options.executeDurabilityOverride) : undefined],
+        ['WaitFor failure', isPresent(options.waitForFailurePolicy) ? waitForFailurePolicyLabel(options.waitForFailurePolicy) : undefined],
+        ['Execute failure', isPresent(options.executeFailurePolicy) ? executeFailurePolicyLabel(options.executeFailurePolicy) : undefined],
+        ['Failure proceeds to', options.executeFailureProceedStepType],
+        ['WaitFor locks', listText(options.waitForLockAttributeKeys)],
+        ['Execute locks', listText(options.executeLockAttributeKeys)],
+      ]} />
+    </div>
+  );
+}
+
+function seconds(value: unknown): string | undefined {
+  return isPresent(value) ? `${String(value)}s` : undefined;
+}
+
+function listText(value: unknown): string | undefined {
+  return Array.isArray(value) && value.length > 0 ? value.map(String).join(', ') : undefined;
+}
+
+function StepMovements({ values }: { values: unknown }) {
+  const movements = asDataArray(values);
+  if (movements.length === 0) return null;
+  return (
+    <div className="semantic-records">
+      {movements.map((movement, index) => (
+        <div className="semantic-record" key={`${String(movement.stepType)}-${index}`}>
+          <Fields values={[
+            ['Step', movement.stepType],
+            ['From', movement.fromStepExecutionIdInternalOnly],
+          ]} />
+          <ValueBlock label="Input" value={movement.stepInput} />
+          <StepOptionsView value={movement.stepOptions} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FlowConfigView({ value }: { value: unknown }) {
+  const config = asData(value);
+  if (!hasData(config)) return null;
+  return (
+    <DetailSection title="Flow configuration">
+      <Fields values={[
+        ['Step durability', isPresent(config.stepDurability) ? durabilityLabel(config.stepDurability) : undefined],
+        ['Active step search', isPresent(config.activeStepSearchMode) ? activeStepSearchModeLabel(config.activeStepSearchMode) : undefined],
+        ['Continue-as-new threshold', config.continueAsNewThreshold],
+        ['Continue-as-new page size', bytes(config.continueAsNewPageSizeInBytes)],
+      ]} />
+    </DetailSection>
+  );
+}
+
+function bytes(value: unknown): string | undefined {
+  return isPresent(value) ? `${String(value)} bytes` : undefined;
+}
+
+function WaitingConditionView({ value }: { value: unknown }) {
+  const condition = asData(value);
+  if (!hasData(condition)) return null;
+  const channels = asDataArray(condition.channelConditions);
+  const timers = asDataArray(condition.timerConditions);
+  const combinations = asDataArray(condition.conditionCombinations);
+  return (
+    <DetailSection title="WaitFor condition">
+      <Fields values={[[
+        'Completion rule',
+        waitingConditionTypeLabel(condition.waitingConditionType),
+      ]]} />
+      {channels.length > 0 && (
+        <div className="semantic-records">
+          {channels.map((channel, index) => (
+            <div className="semantic-record channel-record" key={`${String(channel.channelName)}-${index}`}>
+              <strong><ChannelIcon />{displayScalar(channel.channelName)}</strong>
+              <Fields values={[
+                ['Condition ID', channel.conditionId],
+                ['At least', channel.atLeast],
+                ['At most', channel.atMost],
+              ]} />
+            </div>
+          ))}
+        </div>
+      )}
+      {timers.length > 0 && (
+        <div className="semantic-records">
+          {timers.map((timer, index) => (
+            <div className="semantic-record" key={`${String(timer.conditionId)}-${index}`}>
+              <strong>Timer {index + 1}</strong>
+              <Fields values={[
+                ['Condition ID', timer.conditionId],
+                ['Delay', seconds(timer.durationSeconds)],
+                ['Fires at', unixTime(timer.firingUnixTimestampSeconds)],
+              ]} />
+            </div>
+          ))}
+        </div>
+      )}
+      {combinations.length > 0 && (
+        <div className="semantic-subsection">
+          <h5>Condition combinations</h5>
+          {combinations.map((combination, index) => (
+            <p key={index}>{listText(combination.conditionIds) || '—'}</p>
+          ))}
+        </div>
+      )}
+    </DetailSection>
+  );
+}
+
+function unixTime(value: unknown): string | undefined {
+  if (!isPresent(value)) return undefined;
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return undefined;
+  return new Date(timestamp * 1000).toLocaleString();
+}
+
+function ConditionResultsView({ value }: { value: unknown }) {
+  const results = asData(value);
+  if (!hasData(results)) return null;
+  const channels = asDataArray(results.channelResults);
+  const timers = asDataArray(results.timerResults);
+  return (
+    <DetailSection title="Condition results">
+      {results.waitForFailed === true && <p className="semantic-alert">WaitFor failed</p>}
+      <div className="semantic-records">
+        {channels.map((channel, index) => (
+          <div className="semantic-record channel-record" key={`${String(channel.channelName)}-${index}`}>
+            <strong><ChannelIcon />{displayScalar(channel.channelName)}</strong>
+            <Fields values={[
+              ['Condition ID', channel.conditionId],
+              ['Status', conditionStatusLabel(channel.conditionStatus)],
+            ]} />
+            {Array.isArray(channel.values) && channel.values.map((entry, valueIndex) => (
+              <ValueBlock label={`Value ${valueIndex + 1}`} value={entry} key={valueIndex} />
+            ))}
+          </div>
+        ))}
+        {timers.map((timer, index) => (
+          <div className="semantic-record" key={`${String(timer.conditionId)}-${index}`}>
+            <strong>Timer {index + 1}</strong>
+            <Fields values={[
+              ['Condition ID', timer.conditionId],
+              ['Status', conditionStatusLabel(timer.conditionStatus)],
+            ]} />
+          </div>
+        ))}
+      </div>
+    </DetailSection>
+  );
+}
+
+function StepDecisionView({ value }: { value: unknown }) {
+  const decision = asData(value);
+  if (!hasData(decision)) return null;
+  const close = asData(decision.closeDecision);
+  return (
+    <DetailSection title="Step decision">
+      <StepMovements values={decision.nextSteps} />
+      {hasData(close) && (
+        <div className="semantic-record decision-record">
+          <strong>{closeDecisionTypeLabel(close.closeDecisionType)}</strong>
+          <Fields values={[[
+            'Conditional channels',
+            listText(close.conditionalChannelNames),
+          ]]} />
+          <ValueBlock label="Close input" value={close.closeInput} />
+        </div>
+      )}
+    </DetailSection>
+  );
+}
+
+function FailureView({ value }: { value: unknown }) {
+  const failure = asData(value);
+  if (!hasData(failure)) return null;
+  const errorType = typeof failure.errorType === 'string' && failure.errorType.startsWith('FLOW_ERROR_TYPE_')
+    ? flowErrorTypeLabel(failure.errorType)
+    : failure.errorType;
+  return (
+    <DetailSection title="Failure">
+      <div className="semantic-alert">
+        {isPresent(failure.message) && <strong>{displayScalar(failure.message)}</strong>}
+        <Fields values={[
+          ['Type', errorType],
+          ['Retry state', failure.retryState],
+        ]} />
+        {isPresent(failure.stackTrace) && <pre>{String(failure.stackTrace)}</pre>}
+      </div>
+    </DetailSection>
+  );
+}
+
+function EffectsView({ value }: { value: Data }) {
+  const attributes = value.upsertAttributes;
+  const events = value.recordEvents;
+  const channels = value.publishToChannel;
+  const locals = value.upsertStepExeLocals;
+  if (![attributes, events, channels, locals].some((entry) => Array.isArray(entry) && entry.length > 0)) return null;
+  return (
+    <DetailSection title="Side effects">
+      {Array.isArray(attributes) && attributes.length > 0 && (
+        <div className="semantic-subsection"><h5>Attribute writes</h5><KeyValues values={attributes} /></div>
+      )}
+      {Array.isArray(events) && events.length > 0 && (
+        <div className="semantic-subsection"><h5>Recorded events</h5><KeyValues values={events} /></div>
+      )}
+      {Array.isArray(locals) && locals.length > 0 && (
+        <div className="semantic-subsection"><h5>Step locals</h5><KeyValues values={locals} /></div>
+      )}
+      {Array.isArray(channels) && channels.length > 0 && (
+        <div className="semantic-subsection"><h5>Published channels</h5><ChannelMessages values={channels} /></div>
+      )}
+    </DetailSection>
+  );
+}
+
+function StepMethodDetails({ event }: { event: FlowHistoryEvent }) {
+  const payload = event.payload;
+  const execution = asData(payload.execution);
+  const request = asData(payload.request);
+  const context = asData(request.context);
+  const response = asData(payload.response);
+  const previousFailures = asDataArray(execution.previousAttemptFailures);
+  const isWaitFor = event.type.startsWith('StepWaitFor');
+  return (
+    <>
+      <DetailSection title="Attempt info">
+        <Fields values={[
+          ['Durability', durabilityLabel(execution.durability)],
+          ['Attempt', context.attempt],
+          ['Final attempt', execution.finalAttempt],
+          ['First attempt', context.firstAttemptTimestamp],
+          ['First started', execution.firstStartedTime],
+          ['Duration', execution.duration],
+        ]} />
+        {previousFailures.map((attempt, index) => (
+          <div className="semantic-record" key={index}>
+            <Fields values={[
+              ['Previous attempt', attempt.attempt],
+              ['Failed at', attempt.failedTime],
+            ]} />
+            <FailureView value={attempt.failure} />
+          </div>
+        ))}
+      </DetailSection>
+      <DetailSection title="Method execution context">
+        <Fields values={[
+          ['Execution ID', execution.stepExecutionId ?? context.stepExecutionId],
+          ['Scheduled from', execution.fromStepExecutionId ?? context.fromStepExecutionId],
+        ]} />
+      </DetailSection>
+      {(isPresent(request.stepInput) || Array.isArray(request.attributes) || Array.isArray(request.stepExeLocals)) && (
+        <DetailSection title="Method input">
+          <ValueBlock label="Step input" value={request.stepInput} />
+          {Array.isArray(request.attributes) && request.attributes.length > 0 && (
+            <div className="semantic-subsection"><h5>Attributes</h5><KeyValues values={request.attributes} /></div>
+          )}
+          {Array.isArray(request.stepExeLocals) && request.stepExeLocals.length > 0 && (
+            <div className="semantic-subsection"><h5>Step locals</h5><KeyValues values={request.stepExeLocals} /></div>
+          )}
+        </DetailSection>
+      )}
+      {isWaitFor
+        ? <WaitingConditionView value={response.waitingCondition} />
+        : <ConditionResultsView value={request.conditionResults} />}
+      <StepDecisionView value={response.stepDecision} />
+      <EffectsView value={response} />
+      <FailureView value={payload.failure} />
+    </>
+  );
+}
+
+function InitialStartDetails({ payload }: { payload: Data }) {
+  const start = asData(payload.initialStart);
+  return (
+    <>
+      <DetailSection title="Initial start">
+        <Fields values={[['Start step', start.startStepType]]} />
+        <ValueBlock label="Step input" value={start.stepInput} />
+        <StepOptionsView value={start.stepOptions} />
+      </DetailSection>
+      {Array.isArray(start.initialAttributes) && start.initialAttributes.length > 0 && (
+        <DetailSection title="Initial attributes"><KeyValues values={start.initialAttributes} /></DetailSection>
+      )}
+      <FlowConfigView value={payload.flowConfig} />
+    </>
+  );
+}
+
+function ContinuedStartDetails({ payload }: { payload: Data }) {
+  const continued = asData(payload.continuedStart);
+  const resumes = asDataArray(continued.stepsToResume);
+  const pendingChannels = asData(continued.pendingChannelMessages);
+  return (
+    <>
+      <DetailSection title="Continued run">
+        <Fields values={[['Previous run ID', continued.previousRunId]]} />
+      </DetailSection>
+      {Array.isArray(continued.stepsToStart) && continued.stepsToStart.length > 0 && (
+        <DetailSection title="Steps to start"><StepMovements values={continued.stepsToStart} /></DetailSection>
+      )}
+      {resumes.length > 0 && (
+        <DetailSection title="Steps to resume">
+          <div className="semantic-records">
+            {resumes.map((resume, index) => (
+              <div className="semantic-record" key={`${String(resume.stepExecutionId)}-${index}`}>
+                <Fields values={[['Execution ID', resume.stepExecutionId]]} />
+                <StepMovements values={[resume.step]} />
+                <WaitingConditionView value={resume.waitingCondition} />
+                <KeyValues values={resume.stepExeLocals} />
+              </div>
+            ))}
+          </div>
+        </DetailSection>
+      )}
+      {Object.keys(pendingChannels).length > 0 && (
+        <DetailSection title="Pending channels">
+          <div className="semantic-records">
+            {Object.entries(pendingChannels).map(([name, entry]) => (
+              <div className="semantic-record channel-record" key={name}>
+                <strong><ChannelIcon />{name}</strong>
+                {asArray(asData(entry).values).map((value, index) => (
+                  <ValueBlock label={`Message ${index + 1}`} value={value} key={index} />
+                ))}
+              </div>
+            ))}
+          </div>
+        </DetailSection>
+      )}
+      {Array.isArray(continued.attributes) && continued.attributes.length > 0 && (
+        <DetailSection title="Attributes"><KeyValues values={continued.attributes} /></DetailSection>
+      )}
+      {Array.isArray(continued.completedSteps) && continued.completedSteps.length > 0 && (
+        <DetailSection title="Completed steps"><StepOutputs values={continued.completedSteps} /></DetailSection>
+      )}
+      <FlowConfigView value={payload.flowConfig} />
+    </>
+  );
+}
+
+function FlowClosedDetails({ payload }: { payload: Data }) {
+  const errorType = isPresent(payload.errorType) ? flowErrorTypeLabel(payload.errorType) : undefined;
+  return (
+    <>
+      <DetailSection title="Outcome">
+        <Fields values={[
+          ['Status', flowStatusLabel(payload.flowStatus)],
+          ['Continued to run', payload.continuedToRunId],
+        ]} />
+      </DetailSection>
+      {(isPresent(payload.errorMessage) || (errorType && errorType !== 'Unspecified')) && (
+        <DetailSection title="Failure">
+          <div className="semantic-alert">
+            <strong>{displayScalar(payload.errorMessage)}</strong>
+            <Fields values={[['Type', errorType]]} />
+          </div>
+        </DetailSection>
+      )}
+      {Array.isArray(payload.results) && payload.results.length > 0 && (
+        <DetailSection title="Flow results"><StepOutputs values={payload.results} /></DetailSection>
+      )}
+    </>
+  );
+}
+
+function RPCDetails({ payload }: { payload: Data }) {
+  return (
+    <>
+      <DetailSection title="RPC call">
+        <Fields values={[['RPC name', payload.rpcName]]} />
+        <ValueBlock label="Input" value={payload.input} />
+        <ValueBlock label="Output" value={payload.output} />
+      </DetailSection>
+      <StepDecisionView value={payload.stepDecision} />
+      <EffectsView value={payload} />
+    </>
+  );
+}
+
+function SemanticEventDetails({ event }: { event: FlowHistoryEvent }) {
+  if (event.type.startsWith('StepWaitFor') || event.type.startsWith('StepExecute')) {
+    return <StepMethodDetails event={event} />;
+  }
+  if (event.type === 'FlowStartedOrContinued') {
+    return hasData(asData(event.payload.continuedStart))
+      ? <ContinuedStartDetails payload={event.payload} />
+      : <InitialStartDetails payload={event.payload} />;
+  }
+  if (event.type === 'FlowClosed') return <FlowClosedDetails payload={event.payload} />;
+  if (event.type === 'RpcExecutionCompleted') return <RPCDetails payload={event.payload} />;
+  return (
+    <DetailSection title="Published messages">
+      <ChannelMessages values={event.payload.messages} />
+    </DetailSection>
+  );
+}
+
+export function EventDetails({
+  event,
+}: {
+  event: FlowHistoryEvent;
+}) {
+  const [view, setView] = useState<'details' | 'raw'>('details');
+  return (
+    <div className="event-details">
+      <div className="event-details-content">
+        <div className="event-detail-tabs" role="tablist" aria-label="Event payload view">
+          <button aria-selected={view === 'details'} className={view === 'details' ? 'active' : ''} role="tab" type="button" onClick={() => setView('details')}>Details</button>
+          <button aria-selected={view === 'raw'} className={view === 'raw' ? 'active' : ''} role="tab" type="button" onClick={() => setView('raw')}>Raw JSON</button>
+        </div>
+        {view === 'details'
+          ? <div className="semantic-event"><SemanticEventDetails event={event} /></div>
+          : <pre className="raw-event-json">{JSON.stringify(event.payload, null, 2)}</pre>}
+      </div>
+    </div>
+  );
+}

--- a/web/app/flows/details/FlowStatePanel.tsx
+++ b/web/app/flows/details/FlowStatePanel.tsx
@@ -1,5 +1,21 @@
 import type { FlowHistoryEvent, FlowState, FlowSummary } from '@/lib/types';
+import { waitingConditionTypeLabel } from '@/lib/semantic';
 import { JsonView } from '../../components/JsonView';
+import { EventDetails, eventTitle } from './EventDetails';
+
+type Data = Record<string, unknown>;
+
+function data(value: unknown): Data {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Data : {};
+}
+
+function normalizeWaitingCondition(value: unknown): Data {
+  const condition = data(value);
+  return {
+    ...condition,
+    waitingConditionType: waitingConditionTypeLabel(condition.waitingConditionType),
+  };
+}
 
 export function FlowStatePanel({
   state,
@@ -15,12 +31,12 @@ export function FlowStatePanel({
       {selectedEvent && (
         <section className="sidebar-section">
           <p className="eyebrow">Selected event</p>
-          <h3>{selectedEvent.type}</h3>
+          <h3>{eventTitle(selectedEvent)}</h3>
           <div className="event-meta">
             <span>Event {selectedEvent.eventId}</span>
             <span>{selectedEvent.eventTime || 'No timestamp'}</span>
           </div>
-          <JsonView value={selectedEvent.payload} label="Payload" initiallyOpen />
+          <EventDetails event={selectedEvent} />
         </section>
       )}
 
@@ -37,7 +53,7 @@ export function FlowStatePanel({
             <code>{step.stepExecutionId}</code>
             <span>From {step.fromStepExecutionId || '—'}</span>
             {step.waitingCondition && Object.keys(step.waitingCondition).length > 0 && (
-              <JsonView value={step.waitingCondition} label="Waiting condition" />
+              <JsonView value={normalizeWaitingCondition(step.waitingCondition)} label="Waiting condition" />
             )}
             {step.timers.length > 0 && <JsonView value={step.timers} label={`${step.timers.length} timers`} />}
           </div>

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -20,6 +20,151 @@ interface StepNodeData extends Record<string, unknown> {
   model: StepGraphNode;
 }
 
+type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Completed' | 'Failed' | 'Pending' | 'Not used';
+
+function waitingCondition(node: StepGraphNode): Record<string, unknown> {
+  const response = node.waitFor?.payload.response;
+  if (response && typeof response === 'object') {
+    const condition = (response as Record<string, unknown>).waitingCondition;
+    if (condition && typeof condition === 'object') return condition as Record<string, unknown>;
+  }
+  return node.active?.waitingCondition ?? {};
+}
+
+function conditionCount(condition: Record<string, unknown>, key: string): number {
+  const values = condition[key];
+  return Array.isArray(values) ? values.length : 0;
+}
+
+function channelNames(condition: Record<string, unknown>): string[] {
+  const conditions = condition.channelConditions;
+  if (!Array.isArray(conditions)) return [];
+  return conditions.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') return [];
+    const name = (entry as Record<string, unknown>).channelName;
+    return typeof name === 'string' && name ? [name] : [];
+  });
+}
+
+function ConditionIcon({ type }: { type: 'timer' | 'channel' }) {
+  if (type === 'timer') {
+    return (
+      <svg aria-hidden="true" className="graph-condition-icon" viewBox="0 0 16 16">
+        <circle cx="8" cy="8" r="5.5" />
+        <path d="M8 4.8v3.5l2.4 1.4" />
+      </svg>
+    );
+  }
+  return (
+    <svg aria-hidden="true" className="graph-condition-icon" viewBox="0 0 16 16">
+      <circle cx="4" cy="4" r="1.7" />
+      <circle cx="12" cy="8" r="1.7" />
+      <circle cx="4" cy="12" r="1.7" />
+      <path d="M5.7 4.7 10.3 7M5.7 11.3 10.3 9" />
+    </svg>
+  );
+}
+
+function waitForStatus(node: StepGraphNode): MethodStatus {
+  if (node.waitFor?.type === 'StepWaitForFailed') return 'Failed';
+  if (node.active?.phase === 'Waiting') return 'Waiting';
+  if (node.waitFor) return 'Started';
+  if (node.transient) return 'Not used';
+  if (node.active) return 'Running';
+  return 'Pending';
+}
+
+function executeStatus(node: StepGraphNode): MethodStatus {
+  if (node.execute?.type === 'StepExecuteFailed') return 'Failed';
+  if (node.execute) return 'Completed';
+  if (node.active?.phase === 'Active' && node.waitFor) return 'Running';
+  return 'Pending';
+}
+
+function MethodSection({
+  name,
+  status,
+  event,
+  children,
+  onSelect,
+}: {
+  name: string;
+  status: MethodStatus;
+  event?: FlowHistoryEvent;
+  children?: React.ReactNode;
+  onSelect: (event: FlowHistoryEvent) => void;
+}) {
+  return (
+    <button
+      className={`graph-method graph-method-${name.toLowerCase()} graph-method-${status.toLowerCase().replace(' ', '-')} nodrag nopan`}
+      disabled={!event}
+      type="button"
+      onClick={(clickEvent) => {
+        clickEvent.stopPropagation();
+        if (event) onSelect(event);
+      }}
+    >
+      <span>{name}</span>
+      <strong>{status}</strong>
+      {children}
+    </button>
+  );
+}
+
+function StepNodeLabel({
+  node,
+  onSelect,
+}: {
+  node: StepGraphNode;
+  onSelect: (event: FlowHistoryEvent) => void;
+}) {
+  const condition = waitingCondition(node);
+  const timerCount = conditionCount(condition, 'timerConditions');
+  const channelCount = conditionCount(condition, 'channelConditions');
+  const channels = [...new Set(channelNames(condition))];
+  const channelSummary = channels.length > 0 ? channels.join(', ') : `${channelCount} channel${channelCount === 1 ? '' : 's'}`;
+  return (
+    <div className="graph-step-label">
+      <div className="graph-step-heading">
+        <span>{node.status}</span>
+        <b>{node.label}</b>
+        <code>{node.id}</code>
+      </div>
+      <div className="graph-methods">
+        <MethodSection
+          name="WaitFor"
+          status={waitForStatus(node)}
+          event={node.waitFor}
+          onSelect={onSelect}
+        >
+          {(timerCount > 0 || channelCount > 0) && (
+            <small className="graph-conditions">
+              {timerCount > 0 && (
+                <i title={`${timerCount} timer condition${timerCount === 1 ? '' : 's'}`}>
+                  <ConditionIcon type="timer" />
+                  {timerCount} timer{timerCount === 1 ? '' : 's'}
+                </i>
+              )}
+              {channelCount > 0 && (
+                <i title={channelSummary}>
+                  <ConditionIcon type="channel" />
+                  <span>{channelSummary}</span>
+                </i>
+              )}
+            </small>
+          )}
+        </MethodSection>
+        <MethodSection
+          name="Execute"
+          status={executeStatus(node)}
+          event={node.execute}
+          onSelect={onSelect}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function StepGraph({
   flowId,
   events,
@@ -48,9 +193,12 @@ export function StepGraph({
       id: node.id,
       position: { x: 0, y: 0 },
       className: `step-flow-node node-${node.kind} node-${node.status.toLowerCase()}`,
+      style: { width: node.kind === 'step' ? 340 : 220 },
       data: {
         model: node,
-        label: (
+        label: node.kind === 'step' ? (
+          <StepNodeLabel node={node} onSelect={onSelectEvent} />
+        ) : (
           <div className="graph-node-label">
             <span>{node.kind === 'source' ? 'Source' : node.kind === 'terminal' ? 'Terminal' : node.status}</span>
             {node.previousRunId ? (
@@ -67,14 +215,12 @@ export function StepGraph({
                 <code title={node.previousRunId}>{node.previousRunId}</code>
               </>
             ) : <b>{node.label}</b>}
-            {node.kind === 'step' && <code>{node.id}</code>}
-            {node.transient && <em>Transient</em>}
           </div>
         ),
       },
     }));
     return layoutGraph(raw, edges);
-  }, [edges, graph.nodes]);
+  }, [edges, graph.nodes, onSelectEvent]);
 
   if (!nodes.length) return <div className="card empty-state"><h3>No step topology loaded</h3></div>;
   return (

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import {
   Background,
   Controls,
@@ -20,11 +21,13 @@ interface StepNodeData extends Record<string, unknown> {
 }
 
 export function StepGraph({
+  flowId,
   events,
   state,
   selectedEvent,
   onSelectEvent,
 }: {
+  flowId: string;
   events: FlowHistoryEvent[];
   state: FlowState | null;
   selectedEvent: FlowHistoryEvent | null;
@@ -50,7 +53,20 @@ export function StepGraph({
         label: (
           <div className="graph-node-label">
             <span>{node.kind === 'source' ? 'Source' : node.kind === 'terminal' ? 'Terminal' : node.status}</span>
-            <b>{node.label}</b>
+            {node.previousRunId ? (
+              <>
+                <b>
+                  <Link
+                    className="graph-run-link nodrag nopan"
+                    title={node.previousRunId}
+                    to={`/flows/${encodeURIComponent(flowId)}/${encodeURIComponent(node.previousRunId)}`}
+                  >
+                    Continued from previous run
+                  </Link>
+                </b>
+                <code title={node.previousRunId}>{node.previousRunId}</code>
+              </>
+            ) : <b>{node.label}</b>}
             {node.kind === 'step' && <code>{node.id}</code>}
             {node.transient && <em>Transient</em>}
           </div>

--- a/web/app/flows/details/Timeline.tsx
+++ b/web/app/flows/details/Timeline.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import type { FlowHistoryEvent } from '@/lib/types';
 import { formatDate } from '@/lib/format';
 import { usePreferences } from '../../providers';
 import { JsonView } from '../../components/JsonView';
 
 const eventLabels: Record<FlowHistoryEvent['type'], string> = {
-  FlowStartedOrContinued: 'Flow started / continued',
+  FlowStartedOrContinued: 'Flow started',
   FlowClosed: 'Flow closed',
   StepWaitForCompleted: 'WaitFor completed',
   StepWaitForFailed: 'WaitFor failed',
@@ -31,11 +32,21 @@ function executionSummary(event: FlowHistoryEvent): string {
   return [info.stepType, info.stepExecutionId].filter(Boolean).join(' · ');
 }
 
+function previousRunID(event: FlowHistoryEvent): string {
+  if (event.type !== 'FlowStartedOrContinued') return '';
+  const continued = event.payload.continuedStart;
+  if (!continued || typeof continued !== 'object') return '';
+  const value = (continued as Record<string, unknown>).previousRunId;
+  return typeof value === 'string' ? value : '';
+}
+
 export function Timeline({
+  flowId,
   events,
   selectedEvent,
   onSelectEvent,
 }: {
+  flowId: string;
   events: FlowHistoryEvent[];
   selectedEvent: FlowHistoryEvent | null;
   onSelectEvent: (event: FlowHistoryEvent) => void;
@@ -60,6 +71,7 @@ export function Timeline({
           const eventMs = event.eventTime ? Date.parse(event.eventTime) : 0;
           const relative = startMs && eventMs ? Math.max(0, Math.round((eventMs - startMs) / 1000)) : null;
           const selected = selectedEvent?.eventId === event.eventId;
+          const previousRunId = previousRunID(event);
           return (
             <article
               className={`timeline-row ${selected ? 'selected' : ''}`}
@@ -77,7 +89,17 @@ export function Timeline({
                 <header>
                   <div>
                     <span className="event-id">#{event.eventId}</span>
-                    <h3>{eventLabels[event.type]}</h3>
+                    <h3>
+                      {previousRunId ? (
+                        <Link
+                          className="event-run-link"
+                          title={previousRunId}
+                          to={`/flows/${encodeURIComponent(flowId)}/${encodeURIComponent(previousRunId)}`}
+                        >
+                          Flow continued
+                        </Link>
+                      ) : eventLabels[event.type]}
+                    </h3>
                     {executionSummary(event) && <p>{executionSummary(event)}</p>}
                   </div>
                   <span className={`event-type tone-${eventTone(event)}`}>{event.type}</span>

--- a/web/app/flows/details/Timeline.tsx
+++ b/web/app/flows/details/Timeline.tsx
@@ -1,9 +1,26 @@
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { FlowHistoryEvent } from '@/lib/types';
 import { formatDate } from '@/lib/format';
 import { durabilityLabel } from '@/lib/semantic';
+import { buildTimelineStepLinks, formatElapsedDuration, newestTimelineEvents } from '@/lib/timeline';
 import { usePreferences } from '../../providers';
 import { eventTitle } from './EventDetails';
+
+interface StepLinkPath {
+  id: string;
+  label: string;
+  path: string;
+  duration: string;
+  durationX: number;
+  durationY: number;
+}
+
+interface StepLinkLayout {
+  width: number;
+  height: number;
+  paths: StepLinkPath[];
+}
 
 function eventTone(event: FlowHistoryEvent) {
   if (event.type.endsWith('Failed')) return 'failed';
@@ -40,8 +57,60 @@ export function Timeline({
   onSelectEvent: (event: FlowHistoryEvent) => void;
 }) {
   const { timezone } = usePreferences();
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const eventDots = useRef(new Map<number, HTMLSpanElement>());
+  const orderedEvents = useMemo(() => newestTimelineEvents(events), [events]);
+  const stepLinks = useMemo(() => buildTimelineStepLinks(events), [events]);
+  const [stepLinkLayout, setStepLinkLayout] = useState<StepLinkLayout>({ width: 0, height: 0, paths: [] });
+  const updateStepLinks = useCallback(() => {
+    const timeline = timelineRef.current;
+    if (!timeline) return;
+    const timelineRect = timeline.getBoundingClientRect();
+    const paths = stepLinks.flatMap((link) => {
+      const waitForDot = eventDots.current.get(link.waitForEventId);
+      const executeDot = eventDots.current.get(link.executeEventId);
+      if (!waitForDot || !executeDot) return [];
+      const waitForRect = waitForDot.getBoundingClientRect();
+      const executeRect = executeDot.getBoundingClientRect();
+      const waitForX = waitForRect.right - timelineRect.left + 2;
+      const executeX = executeRect.right - timelineRect.left + 2;
+      const waitForY = waitForRect.top + waitForRect.height / 2 - timelineRect.top;
+      const executeY = executeRect.top + executeRect.height / 2 - timelineRect.top;
+      const linkX = Math.max(waitForX, executeX) + 15;
+      const duration = formatElapsedDuration(link.conditionWaitDurationMs);
+      return [{
+        id: `${link.stepExecutionId}-${link.waitForEventId}-${link.executeEventId}`,
+        label: `${link.stepExecutionId}: WaitForCondition started to Execute`,
+        path: `M ${waitForX} ${waitForY} H ${linkX} V ${executeY} H ${executeX}`,
+        duration,
+        durationX: linkX + 6,
+        durationY: (waitForY + executeY) / 2,
+      }];
+    });
+    setStepLinkLayout({ width: timelineRect.width, height: timelineRect.height, paths });
+  }, [stepLinks]);
+
+  useLayoutEffect(() => {
+    const timeline = timelineRef.current;
+    if (!timeline) return;
+    const frame = window.requestAnimationFrame(updateStepLinks);
+    const observer = new ResizeObserver(updateStepLinks);
+    observer.observe(timeline);
+    eventDots.current.forEach((dot) => observer.observe(dot));
+    window.addEventListener('resize', updateStepLinks);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener('resize', updateStepLinks);
+    };
+  }, [orderedEvents, updateStepLinks]);
+
   if (!events.length) return <div className="card empty-state"><h3>No semantic events loaded</h3></div>;
-  const startMs = events[0].eventTime ? Date.parse(events[0].eventTime) : 0;
+  const startMs = events.reduce((earliest, event) => {
+    const eventMs = event.eventTime ? Date.parse(event.eventTime) : 0;
+    if (!eventMs) return earliest;
+    return earliest ? Math.min(earliest, eventMs) : eventMs;
+  }, 0);
   return (
     <div className="timeline-wrap">
       <div className="view-toolbar">
@@ -50,8 +119,40 @@ export function Timeline({
           <h2>{events.length} events</h2>
         </div>
       </div>
-      <div className="timeline">
-        {events.map((event) => {
+      <div className="timeline" ref={timelineRef}>
+        {stepLinkLayout.paths.length > 0 && (
+          <svg
+            aria-hidden="true"
+            className="timeline-step-links"
+            height={stepLinkLayout.height}
+            viewBox={`0 0 ${stepLinkLayout.width} ${stepLinkLayout.height}`}
+            width={stepLinkLayout.width}
+          >
+            <defs>
+              <marker id="timeline-step-arrow" markerHeight="7" markerWidth="7" orient="auto" refX="5" refY="3.5">
+                <path d="M 0 0 L 6 3.5 L 0 7 z" />
+              </marker>
+            </defs>
+            {stepLinkLayout.paths.map((link) => (
+              <g key={link.id}>
+                <path className="timeline-step-link" d={link.path} markerEnd="url(#timeline-step-arrow)">
+                  <title>{link.label}</title>
+                </path>
+                {link.duration && (
+                  <text
+                    className="timeline-step-duration"
+                    dominantBaseline="middle"
+                    x={link.durationX}
+                    y={link.durationY}
+                  >
+                    {link.duration}
+                  </text>
+                )}
+              </g>
+            ))}
+          </svg>
+        )}
+        {orderedEvents.map((event) => {
           const eventMs = event.eventTime ? Date.parse(event.eventTime) : 0;
           const relative = startMs && eventMs ? Math.max(0, Math.round((eventMs - startMs) / 1000)) : null;
           const selected = selectedEvent?.eventId === event.eventId;
@@ -67,7 +168,13 @@ export function Timeline({
                 {relative !== null && <span>+{relative}s</span>}
               </div>
               <div className="timeline-rail">
-                <span className={`timeline-dot tone-${eventTone(event)}`} />
+                <span
+                  className={`timeline-dot tone-${eventTone(event)}`}
+                  ref={(node) => {
+                    if (node) eventDots.current.set(event.eventId, node);
+                    else eventDots.current.delete(event.eventId);
+                  }}
+                />
               </div>
               <div className="event-card">
                 <header>

--- a/web/app/flows/details/Timeline.tsx
+++ b/web/app/flows/details/Timeline.tsx
@@ -1,25 +1,13 @@
-'use client';
-
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { FlowHistoryEvent } from '@/lib/types';
 import { formatDate } from '@/lib/format';
+import { durabilityLabel } from '@/lib/semantic';
 import { usePreferences } from '../../providers';
-import { JsonView } from '../../components/JsonView';
-
-const eventLabels: Record<FlowHistoryEvent['type'], string> = {
-  FlowStartedOrContinued: 'Flow started',
-  FlowClosed: 'Flow closed',
-  StepWaitForCompleted: 'WaitFor completed',
-  StepWaitForFailed: 'WaitFor failed',
-  StepExecuteCompleted: 'Execute completed',
-  StepExecuteFailed: 'Execute failed',
-  RpcExecutionCompleted: 'RPC completed',
-  ChannelExternalPublish: 'Channel published',
-};
+import { eventTitle } from './EventDetails';
 
 function eventTone(event: FlowHistoryEvent) {
   if (event.type.endsWith('Failed')) return 'failed';
+  if (event.type === 'StepWaitForCompleted') return 'waiting';
   if (event.type.endsWith('Completed')) return 'completed';
   if (event.type === 'FlowClosed') return 'closed';
   return 'neutral';
@@ -52,7 +40,6 @@ export function Timeline({
   onSelectEvent: (event: FlowHistoryEvent) => void;
 }) {
   const { timezone } = usePreferences();
-  const [expandAll, setExpandAll] = useState(false);
   if (!events.length) return <div className="card empty-state"><h3>No semantic events loaded</h3></div>;
   const startMs = events[0].eventTime ? Date.parse(events[0].eventTime) : 0;
   return (
@@ -62,9 +49,6 @@ export function Timeline({
           <p className="eyebrow">Dex semantic history</p>
           <h2>{events.length} events</h2>
         </div>
-        <button className="button ghost" onClick={() => setExpandAll(!expandAll)}>
-          {expandAll ? 'Collapse all' : 'Expand all'}
-        </button>
       </div>
       <div className="timeline">
         {events.map((event) => {
@@ -98,19 +82,13 @@ export function Timeline({
                         >
                           Flow continued
                         </Link>
-                      ) : eventLabels[event.type]}
+                      ) : eventTitle(event)}
                     </h3>
                     {executionSummary(event) && <p>{executionSummary(event)}</p>}
                   </div>
                   <span className={`event-type tone-${eventTone(event)}`}>{event.type}</span>
                 </header>
                 <EventHighlights event={event} />
-                <JsonView
-                  key={`${event.eventId}-${expandAll}`}
-                  value={event.payload}
-                  label="Event details"
-                  initiallyOpen={expandAll}
-                />
               </div>
             </article>
           );
@@ -126,9 +104,8 @@ function EventHighlights({ event }: { event: FlowHistoryEvent }) {
   if (!execution && !failure) return null;
   return (
     <div className="event-highlights">
-      {execution?.durability !== undefined && <span>Durability <b>{String(execution.durability)}</b></span>}
+      {execution?.durability !== undefined && <span>Durability <b>{durabilityLabel(execution.durability)}</b></span>}
       {execution?.finalAttempt !== undefined && <span>Final attempt <b>{String(execution.finalAttempt)}</b></span>}
-      {execution?.isTransientStep === true && <span className="transient-chip">Transient</span>}
       {typeof failure?.message === 'string' && failure.message && (
         <span className="failure-message">{failure.message}</span>
       )}

--- a/web/app/flows/details/graphLayout.ts
+++ b/web/app/flows/details/graphLayout.ts
@@ -9,14 +9,21 @@ export function layoutGraph<NodeData extends Record<string, unknown>>(
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
   graph.setGraph({ rankdir: direction, ranksep: 80, nodesep: 44, marginx: 30, marginy: 30 });
-  nodes.forEach((node) => graph.setNode(node.id, { width: 220, height: 90 }));
+  nodes.forEach((node) => graph.setNode(node.id, {
+    width: typeof node.style?.width === 'number' ? node.style.width : 220,
+    height: node.data.model && typeof node.data.model === 'object'
+      && (node.data.model as { kind?: string }).kind === 'step' ? 158 : 90,
+  }));
   edges.forEach((edge) => graph.setEdge(edge.source, edge.target));
   dagre.layout(graph);
   return nodes.map((node) => {
     const position = graph.node(node.id);
+    const width = typeof node.style?.width === 'number' ? node.style.width : 220;
+    const height = node.data.model && typeof node.data.model === 'object'
+      && (node.data.model as { kind?: string }).kind === 'step' ? 158 : 90;
     return {
       ...node,
-      position: { x: position.x - 110, y: position.y - 45 },
+      position: { x: position.x - width / 2, y: position.y - height / 2 },
     };
   });
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1110,6 +1110,20 @@ pre {
   margin-left: 8px;
 }
 
+.event-run-link,
+.graph-run-link {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(75, 122, 42, 0.35);
+  text-underline-offset: 3px;
+}
+
+.event-run-link:hover,
+.graph-run-link:hover {
+  color: var(--brand-dark);
+  text-decoration-color: currentColor;
+}
+
 .event-card header p {
   margin: 6px 0 0;
   color: var(--muted);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1238,8 +1238,43 @@ pre {
 
 .timeline-row {
   display: grid;
-  grid-template-columns: 145px 28px minmax(0, 1fr);
+  grid-template-columns: 145px 88px minmax(0, 1fr);
   cursor: pointer;
+}
+
+.timeline {
+  position: relative;
+}
+
+.timeline-step-links {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  left: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.timeline-step-link {
+  fill: none;
+  stroke: #4f87a3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2px;
+}
+
+#timeline-step-arrow path {
+  fill: #4f87a3;
+}
+
+.timeline-step-duration {
+  fill: #3b6479;
+  font-size: 10px;
+  font-weight: 700;
+  paint-order: stroke;
+  stroke: white;
+  stroke-linejoin: round;
+  stroke-width: 5px;
 }
 
 .timeline-row.selected .event-card {
@@ -1268,13 +1303,14 @@ pre {
 .timeline-rail {
   position: relative;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .timeline-rail::before {
   position: absolute;
   top: 0;
   bottom: 0;
+  left: 13px;
   width: 1px;
   content: "";
   background: var(--line);
@@ -1285,6 +1321,7 @@ pre {
   width: 10px;
   height: 10px;
   margin-top: 17px;
+  margin-left: 8px;
   border: 2px solid white;
   border-radius: 50%;
   background: #8da09b;
@@ -1814,7 +1851,7 @@ pre {
   }
 
   .timeline-row {
-    grid-template-columns: 18px minmax(0, 1fr);
+    grid-template-columns: 74px minmax(0, 1fr);
   }
 
   .timeline-time {
@@ -1827,6 +1864,14 @@ pre {
   .timeline-rail {
     grid-column: 1;
     grid-row: 1 / 3;
+  }
+
+  .timeline-rail::before {
+    left: 8px;
+  }
+
+  .timeline-dot {
+    margin-left: 3px;
   }
 
   .event-card {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -852,6 +852,216 @@ pre {
   font-size: 11px;
 }
 
+.event-details {
+  margin-top: 10px;
+}
+
+.event-details-content {
+  min-width: 0;
+}
+
+.event-detail-tabs {
+  display: grid;
+  padding: 4px;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: #f3f6f5;
+}
+
+.event-detail-tabs button {
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  background: transparent;
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.event-detail-tabs button.active {
+  color: var(--brand-dark);
+  background: white;
+  box-shadow: 0 1px 4px rgba(28, 51, 45, 0.1);
+}
+
+.semantic-event {
+  display: flex;
+  margin-top: 10px;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.semantic-section {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: #fbfcfc;
+}
+
+.semantic-section h4,
+.semantic-section h5 {
+  margin: 0 0 8px;
+  color: var(--ink);
+}
+
+.semantic-section h4 {
+  font-size: 11px;
+}
+
+.semantic-section h5 {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.semantic-fields {
+  display: grid;
+  margin: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.semantic-fields > div {
+  min-width: 0;
+}
+
+.semantic-fields dt {
+  margin-bottom: 2px;
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.semantic-fields dd {
+  overflow: hidden;
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.semantic-value {
+  display: flex;
+  min-width: 0;
+  margin-top: 8px;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.semantic-value > span {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.semantic-value code,
+.semantic-value pre,
+.semantic-alert pre {
+  margin: 0;
+  padding: 7px;
+  overflow: auto;
+  border: 1px solid #e1e8e5;
+  border-radius: 6px;
+  color: #33413e;
+  background: white;
+  font-size: 9px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.semantic-records {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.semantic-record {
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid #e1e8e5;
+  border-radius: 7px;
+  background: white;
+}
+
+.semantic-record > strong {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 7px;
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.channel-record > strong {
+  color: #765620;
+}
+
+.channel-record svg {
+  width: 13px;
+  min-width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.4;
+}
+
+.semantic-subsection + .semantic-subsection,
+.semantic-fields + .semantic-records,
+.semantic-fields + .semantic-subsection {
+  margin-top: 10px;
+}
+
+.semantic-subsection > p {
+  margin: 4px 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.decision-record {
+  border-color: #cbdcbc;
+  background: #f4faef;
+}
+
+.semantic-alert {
+  padding: 8px;
+  border: 1px solid #efcaca;
+  border-radius: 7px;
+  color: #922f2f;
+  background: #fdf1f1;
+  font-size: 10px;
+}
+
+.semantic-alert > strong {
+  display: block;
+  margin-bottom: 7px;
+}
+
+.raw-event-json {
+  max-height: 520px;
+  margin: 10px 0 0;
+  padding: 11px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: #33413e;
+  background: #fbfcfc;
+  font-size: 10px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.run-sidebar .semantic-fields {
+  grid-template-columns: 1fr;
+}
+
 .json-view {
   margin-top: 8px;
   overflow: hidden;
@@ -1157,6 +1367,16 @@ pre {
   background: var(--brand-soft);
 }
 
+.timeline-dot.tone-waiting {
+  background: #d39732;
+  box-shadow: 0 0 0 1px #d39732;
+}
+
+.event-type.tone-waiting {
+  color: #805817;
+  background: #f7eacd;
+}
+
 .event-highlights {
   display: flex;
   flex-wrap: wrap;
@@ -1175,11 +1395,6 @@ pre {
 .event-highlights .failure-message {
   color: #922f2f;
   background: #fae9e9;
-}
-
-.event-highlights .transient-chip {
-  color: #705012;
-  background: #f6e8c8;
 }
 
 .graph-legend {
@@ -1277,10 +1492,8 @@ pre {
 
 .graph-node-label > span {
   color: var(--muted);
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .graph-node-label b {
@@ -1298,16 +1511,152 @@ pre {
   white-space: nowrap;
 }
 
-.graph-node-label em {
-  align-self: flex-start;
-  padding: 2px 5px;
-  border-radius: 4px;
-  color: #765620;
-  background: #f5ebd6;
-  font-size: 8px;
-  font-style: normal;
+.graph-step-label {
+  min-height: 136px;
+}
+
+.graph-step-heading {
+  position: relative;
+  display: grid;
+  padding: 10px 12px 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 3px 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.graph-step-heading > span {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 10px;
   font-weight: 800;
-  text-transform: uppercase;
+}
+
+.graph-step-heading b,
+.graph-step-heading code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-step-heading b {
+  font-size: 12px;
+}
+
+.graph-step-heading code {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.graph-methods {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.graph-method {
+  display: flex;
+  min-width: 0;
+  min-height: 70px;
+  padding: 9px 11px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  border: 0;
+  color: inherit;
+  text-align: left;
+  background: #fbfcfc;
+  cursor: pointer;
+}
+
+.graph-method-waitfor {
+  background: #fff8e7;
+}
+
+.graph-method-execute {
+  background: #eef8ed;
+}
+
+.graph-method + .graph-method {
+  border-left: 1px solid var(--line);
+}
+
+.graph-method-waitfor:hover:not(:disabled) {
+  background: #fff0c9;
+}
+
+.graph-method-execute:hover:not(:disabled) {
+  background: #e0f2de;
+}
+
+.graph-method:focus-visible {
+  z-index: 1;
+  outline: 2px solid var(--brand);
+  outline-offset: -2px;
+}
+
+.graph-method:disabled {
+  cursor: default;
+  opacity: 0.62;
+}
+
+.graph-method span {
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.graph-method strong {
+  font-size: 10px;
+}
+
+.graph-method .graph-conditions {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.graph-method .graph-conditions i {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  color: #765620;
+  font-size: 9px;
+  font-style: normal;
+  white-space: nowrap;
+}
+
+.graph-method .graph-conditions i span {
+  overflow: hidden;
+  color: inherit;
+  font-size: inherit;
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.graph-condition-icon {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.4;
+}
+
+.graph-method-failed strong {
+  color: var(--danger);
+}
+
+.graph-method-execute strong {
+  color: var(--brand-dark);
+}
+
+.graph-method-waitfor strong {
+  color: #8a5d17;
 }
 
 .graph-selection {

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -24,6 +24,13 @@ function stringField(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+function previousRunID(events: FlowHistoryEvent[]): string {
+  const started = events.find((event) => event.type === 'FlowStartedOrContinued');
+  const continued = started?.payload.continuedStart;
+  if (!continued || typeof continued !== 'object') return '';
+  return stringField((continued as Record<string, unknown>).previousRunId);
+}
+
 export function buildStepGraph(
   events: FlowHistoryEvent[],
   activeSteps: ActiveStepExecution[] = [],
@@ -34,6 +41,7 @@ export function buildStepGraph(
     label: 'Flow start',
     kind: 'source',
     status: 'Source',
+    previousRunId: previousRunID(events),
   });
 
   for (const event of events) {

--- a/web/lib/semantic.ts
+++ b/web/lib/semantic.ts
@@ -1,0 +1,129 @@
+function enumLabel(value: unknown, labels: Record<string, string>): string {
+  const key = String(value ?? 0);
+  return labels[key] ?? `Unknown (${key})`;
+}
+
+export function durabilityLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Synchronous',
+    2: 'Asynchronous',
+    STEP_DURABILITY_UNSPECIFIED: 'Unspecified',
+    STEP_DURABILITY_SYNC: 'Synchronous',
+    STEP_DURABILITY_ASYNC: 'Asynchronous',
+  });
+}
+
+export function waitingConditionTypeLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'All completed',
+    2: 'Any completed',
+    3: 'Any combination completed',
+    WAITING_CONDITION_TYPE_UNSPECIFIED: 'Unspecified',
+    WAITING_CONDITION_TYPE_ALL_COMPLETED: 'All completed',
+    WAITING_CONDITION_TYPE_ANY_COMPLETED: 'Any completed',
+    WAITING_CONDITION_TYPE_ANY_COMBINATION_COMPLETED: 'Any combination completed',
+  });
+}
+
+export function conditionStatusLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Waiting',
+    2: 'Completed',
+    CONDITION_STATUS_UNSPECIFIED: 'Unspecified',
+    CONDITION_STATUS_WAITING: 'Waiting',
+    CONDITION_STATUS_COMPLETED: 'Completed',
+  });
+}
+
+export function flowStatusLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Running',
+    2: 'Completed',
+    3: 'Failed',
+    4: 'Timed out',
+    5: 'Terminated',
+    6: 'Canceled',
+    7: 'Continued as new',
+    FLOW_STATUS_UNSPECIFIED: 'Unspecified',
+    FLOW_STATUS_RUNNING: 'Running',
+    FLOW_STATUS_COMPLETED: 'Completed',
+    FLOW_STATUS_FAILED: 'Failed',
+    FLOW_STATUS_TIMEOUT: 'Timed out',
+    FLOW_STATUS_TERMINATED: 'Terminated',
+    FLOW_STATUS_CANCELED: 'Canceled',
+    FLOW_STATUS_CONTINUED_AS_NEW: 'Continued as new',
+  });
+}
+
+export function flowErrorTypeLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Step decision failed the flow',
+    2: 'Client API failed the flow',
+    3: 'Worker method failed',
+    4: 'Invalid flow code',
+    6: 'Internal error',
+    FLOW_ERROR_TYPE_UNSPECIFIED: 'Unspecified',
+    FLOW_ERROR_TYPE_STEP_DECISION_FAILING_FLOW: 'Step decision failed the flow',
+    FLOW_ERROR_TYPE_CLIENT_API_FAILING_FLOW: 'Client API failed the flow',
+    FLOW_ERROR_TYPE_WORKER_API_FAIL: 'Worker method failed',
+    FLOW_ERROR_TYPE_INVALID_USER_FLOW_CODE: 'Invalid flow code',
+    FLOW_ERROR_TYPE_INTERNAL: 'Internal error',
+  });
+}
+
+export function closeDecisionTypeLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Complete when channels are empty',
+    2: 'Graceful complete',
+    3: 'Force complete',
+    4: 'Force fail',
+    5: 'Dead end',
+    CLOSE_DECISION_TYPE_UNSPECIFIED: 'Unspecified',
+    CLOSE_DECISION_TYPE_FORCE_COMPLETE_ON_CHANNELS_EMPTY: 'Complete when channels are empty',
+    CLOSE_DECISION_TYPE_GRACEFUL_COMPLETE: 'Graceful complete',
+    CLOSE_DECISION_TYPE_FORCE_COMPLETE: 'Force complete',
+    CLOSE_DECISION_TYPE_FORCE_FAIL: 'Force fail',
+    CLOSE_DECISION_TYPE_DEAD_END: 'Dead end',
+  });
+}
+
+export function activeStepSearchModeLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'All steps',
+    2: 'Steps with WaitFor',
+    3: 'Disabled',
+    ACTIVE_STEP_SEARCH_MODE_UNSPECIFIED: 'Unspecified',
+    ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_ALL: 'All steps',
+    ACTIVE_STEP_SEARCH_MODE_ENABLED_FOR_STEPS_WITH_WAIT_FOR: 'Steps with WaitFor',
+    ACTIVE_STEP_SEARCH_MODE_DISABLED: 'Disabled',
+  });
+}
+
+export function waitForFailurePolicyLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Fail flow',
+    2: 'Proceed',
+    WAIT_FOR_METHOD_FAILURE_POLICY_UNSPECIFIED: 'Unspecified',
+    WAIT_FOR_METHOD_FAILURE_POLICY_FAIL_FLOW_ON_FAILURE: 'Fail flow',
+    WAIT_FOR_METHOD_FAILURE_POLICY_PROCEED_ON_FAILURE: 'Proceed',
+  });
+}
+
+export function executeFailurePolicyLabel(value: unknown): string {
+  return enumLabel(value, {
+    0: 'Unspecified',
+    1: 'Fail flow',
+    2: 'Proceed to configured step',
+    EXECUTE_METHOD_FAILURE_POLICY_UNSPECIFIED: 'Unspecified',
+    EXECUTE_METHOD_FAILURE_POLICY_FAIL_FLOW_ON_EXECUTE_METHOD_FAILURE: 'Fail flow',
+    EXECUTE_METHOD_FAILURE_POLICY_PROCEED_TO_CONFIGURED_STEP: 'Proceed to configured step',
+  });
+}

--- a/web/lib/timeline.test.ts
+++ b/web/lib/timeline.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { buildTimelineStepLinks, formatElapsedDuration, newestTimelineEvents } from './timeline';
+import type { FlowHistoryEvent } from './types';
+
+function event(
+  eventId: number,
+  type: FlowHistoryEvent['type'],
+  stepExecutionId = '',
+  eventTime: string | null = null,
+  firstStartedTime: string | null = null,
+): FlowHistoryEvent {
+  return {
+    eventId,
+    eventTime,
+    type,
+    payload: stepExecutionId ? { execution: { stepExecutionId, firstStartedTime } } : {},
+  };
+}
+
+describe('timeline', () => {
+  it('shows newest events first without mutating history order', () => {
+    const history = [event(1, 'FlowStartedOrContinued'), event(8, 'FlowClosed'), event(4, 'ChannelExternalPublish')];
+    expect(newestTimelineEvents(history).map((entry) => entry.eventId)).toEqual([8, 4, 1]);
+    expect(history.map((entry) => entry.eventId)).toEqual([1, 8, 4]);
+  });
+
+  it('pairs each WaitFor start with the following Execute result for the same execution', () => {
+    const links = buildTimelineStepLinks([
+      event(40, 'StepExecuteCompleted', 'B-1'),
+      event(10, 'StepWaitForCompleted', 'A-1'),
+      event(30, 'StepWaitForCompleted', 'B-1'),
+      event(20, 'StepExecuteFailed', 'A-1'),
+    ]);
+    expect(links).toEqual([
+      { stepExecutionId: 'A-1', waitForEventId: 10, executeEventId: 20, conditionWaitDurationMs: null },
+      { stepExecutionId: 'B-1', waitForEventId: 30, executeEventId: 40, conditionWaitDurationMs: null },
+    ]);
+  });
+
+  it('measures condition wait until Execute starts', () => {
+    const links = buildTimelineStepLinks([
+      event(10, 'StepWaitForCompleted', 'A-1', '2026-08-03T20:00:00.000Z'),
+      event(20, 'StepExecuteCompleted', 'A-1', '2026-08-03T20:00:09.000Z', '2026-08-03T20:00:07.250Z'),
+    ]);
+    expect(links[0].conditionWaitDurationMs).toBe(7250);
+  });
+
+  it('ignores WaitFor failures and unpaired Execute events', () => {
+    expect(buildTimelineStepLinks([
+      event(1, 'StepWaitForFailed', 'A-1'),
+      event(2, 'StepExecuteCompleted', 'A-1'),
+      event(3, 'StepExecuteCompleted', 'B-1'),
+    ])).toEqual([]);
+  });
+
+  it('formats elapsed condition waits compactly', () => {
+    expect(formatElapsedDuration(450)).toBe('450ms');
+    expect(formatElapsedDuration(7250)).toBe('7.3s');
+    expect(formatElapsedDuration(65_000)).toBe('1m 5s');
+    expect(formatElapsedDuration(3_720_000)).toBe('1h 2m');
+  });
+});

--- a/web/lib/timeline.ts
+++ b/web/lib/timeline.ts
@@ -1,0 +1,75 @@
+import type { FlowHistoryEvent } from './types';
+
+export interface TimelineStepLink {
+  stepExecutionId: string;
+  waitForEventId: number;
+  executeEventId: number;
+  conditionWaitDurationMs: number | null;
+}
+
+export function newestTimelineEvents(events: FlowHistoryEvent[]): FlowHistoryEvent[] {
+  return [...events].sort((left, right) => right.eventId - left.eventId);
+}
+
+export function buildTimelineStepLinks(events: FlowHistoryEvent[]): TimelineStepLink[] {
+  const pendingWaitFor = new Map<string, FlowHistoryEvent>();
+  const links: TimelineStepLink[] = [];
+  const chronologicalEvents = [...events].sort((left, right) => left.eventId - right.eventId);
+
+  for (const event of chronologicalEvents) {
+    const stepExecutionId = executionID(event);
+    if (!stepExecutionId) continue;
+    if (event.type === 'StepWaitForCompleted') {
+      pendingWaitFor.set(stepExecutionId, event);
+      continue;
+    }
+    if (event.type !== 'StepExecuteCompleted' && event.type !== 'StepExecuteFailed') continue;
+    const waitForEvent = pendingWaitFor.get(stepExecutionId);
+    if (!waitForEvent) continue;
+    links.push({
+      stepExecutionId,
+      waitForEventId: waitForEvent.eventId,
+      executeEventId: event.eventId,
+      conditionWaitDurationMs: elapsedMilliseconds(waitForEvent.eventTime, executeStartedTime(event)),
+    });
+    pendingWaitFor.delete(stepExecutionId);
+  }
+  return links;
+}
+
+export function formatElapsedDuration(milliseconds: number | null): string {
+  if (milliseconds === null || !Number.isFinite(milliseconds)) return '';
+  const elapsed = Math.max(0, milliseconds);
+  if (elapsed < 1000) return `${Math.round(elapsed)}ms`;
+  if (elapsed < 10_000) return `${Number((elapsed / 1000).toFixed(1))}s`;
+  const seconds = Math.round(elapsed / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function executionID(event: FlowHistoryEvent): string {
+  const execution = event.payload.execution;
+  if (!execution || typeof execution !== 'object') return '';
+  const value = (execution as Record<string, unknown>).stepExecutionId;
+  return typeof value === 'string' ? value : '';
+}
+
+function executeStartedTime(event: FlowHistoryEvent): string | null {
+  const execution = event.payload.execution;
+  if (execution && typeof execution === 'object') {
+    const value = (execution as Record<string, unknown>).firstStartedTime;
+    if (typeof value === 'string') return value;
+  }
+  return event.eventTime;
+}
+
+function elapsedMilliseconds(start: string | null, end: string | null): number | null {
+  if (!start || !end) return null;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
+  return Math.max(0, endMs - startMs);
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -93,6 +93,7 @@ export interface StepGraphNode {
   label: string;
   kind: 'source' | 'step' | 'terminal';
   status: 'Source' | 'Active' | 'Waiting' | 'Completed' | 'Failed' | 'Terminal';
+  previousRunId?: string;
   stepType?: string;
   fromStepExecutionId?: string;
   waitFor?: FlowHistoryEvent;


### PR DESCRIPTION
## What changed

- link continued runs from Timeline and Step Graph without merging run histories
- replace raw payload-first views with structured details for flow, step method, RPC, and channel events
- split WaitFor and Execute presentation in Step Graph with condition-specific visuals
- show Timeline events newest-first and connect each WaitForCondition to its Execute result
- display condition wait duration beside the Timeline connection
- add an opt-out for ContinueAsNew-named tests when running integration tests against local `dexcli dev`

## Why

The flow detail views did not expose Dex semantics clearly: continued runs looked disconnected, payloads required reading raw JSON, and Timeline entries did not show the lifecycle relationship between WaitForCondition and Execute. The local integration target also made it difficult to generate simple non-ContinueAsNew histories for Web inspection.

## Impact

Users can navigate run boundaries explicitly, understand event payloads without decoding engine-oriented JSON, and see how long each step waited for its condition before Execute began. Contributors can run a simpler local Temporal integration subset for visual testing.

## Validation

- `cd web && npm run check`
- `cd web && npm run build`
- visually verified against real Temporal history through Dex Web on port 19802
