### PR TITLE
Refine Dex Web flow visualization

### DIFF
--- a/web/app/flows/details/EventDetails.tsx
+++ b/web/app/flows/details/EventDetails.tsx
@@ -95,10 +95,10 @@ function displayScalar(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function DetailSection({ title, children }: { title: string; children: React.ReactNode }) {
+function DetailSection({ title, children }: { title?: string; children: React.ReactNode }) {
   return (
     <section className="semantic-section">
-      <h4>{title}</h4>
+      {title && <h4>{title}</h4>}
       {children}
     </section>
   );
@@ -474,11 +474,11 @@ function StepMethodDetails({ event }: { event: FlowHistoryEvent }) {
   );
 }
 
-function InitialStartDetails({ payload }: { payload: Data }) {
+function InitialStartDetails({ payload, showHeading = true }: { payload: Data; showHeading?: boolean }) {
   const start = asData(payload.initialStart);
   return (
     <>
-      <DetailSection title="Initial start">
+      <DetailSection title={showHeading ? 'Initial start' : undefined}>
         <Fields values={[['Start step', start.startStepType]]} />
         <ValueBlock label="Step input" value={start.stepInput} />
         <StepOptionsView value={start.stepOptions} />
@@ -491,13 +491,13 @@ function InitialStartDetails({ payload }: { payload: Data }) {
   );
 }
 
-function ContinuedStartDetails({ payload }: { payload: Data }) {
+function ContinuedStartDetails({ payload, showHeading = true }: { payload: Data; showHeading?: boolean }) {
   const continued = asData(payload.continuedStart);
   const resumes = asDataArray(continued.stepsToResume);
   const pendingChannels = asData(continued.pendingChannelMessages);
   return (
     <>
-      <DetailSection title="Continued run">
+      <DetailSection title={showHeading ? 'Continued run' : undefined}>
         <Fields values={[['Previous run ID', continued.previousRunId]]} />
       </DetailSection>
       {Array.isArray(continued.stepsToStart) && continued.stepsToStart.length > 0 && (
@@ -581,14 +581,20 @@ function RPCDetails({ payload }: { payload: Data }) {
   );
 }
 
-function SemanticEventDetails({ event }: { event: FlowHistoryEvent }) {
+export function SemanticEventDetails({
+  event,
+  showStartHeading = true,
+}: {
+  event: FlowHistoryEvent;
+  showStartHeading?: boolean;
+}) {
   if (event.type.startsWith('StepWaitFor') || event.type.startsWith('StepExecute')) {
     return <StepMethodDetails event={event} />;
   }
   if (event.type === 'FlowStartedOrContinued') {
     return hasData(asData(event.payload.continuedStart))
-      ? <ContinuedStartDetails payload={event.payload} />
-      : <InitialStartDetails payload={event.payload} />;
+      ? <ContinuedStartDetails payload={event.payload} showHeading={showStartHeading} />
+      : <InitialStartDetails payload={event.payload} showHeading={showStartHeading} />;
   }
   if (event.type === 'FlowClosed') return <FlowClosedDetails payload={event.payload} />;
   if (event.type === 'RpcExecutionCompleted') return <RPCDetails payload={event.payload} />;

--- a/web/app/flows/details/FlowOverview.tsx
+++ b/web/app/flows/details/FlowOverview.tsx
@@ -8,6 +8,7 @@
 
 import type { FlowHistoryEvent, FlowState, FlowSummary } from '@/lib/types';
 import { JsonView } from '../../components/JsonView';
+import { SemanticEventDetails } from './EventDetails';
 
 export function FlowOverview({
   summary,
@@ -41,7 +42,9 @@ export function FlowOverview({
           <div><p className="eyebrow">Run input</p><h2>{startKind}</h2></div>
         </div>
         {started ? (
-          <JsonView value={started.payload} label="Start payload" initiallyOpen />
+          <div className="semantic-event">
+            <SemanticEventDetails event={started} showStartHeading={false} />
+          </div>
         ) : (
           <p className="muted">The start event is not in the loaded history page.</p>
         )}
@@ -62,7 +65,7 @@ export function FlowOverview({
           </div>
         </div>
         {state?.flowConfig && <JsonView value={state.flowConfig} label="Flow config" />}
-        {closed && <JsonView value={closed.payload} label="Close result" />}
+        {closed && <JsonView value={closed.payload.results ?? []} label="Close result" />}
       </section>
     </div>
   );

--- a/web/app/flows/details/StepGraph.tsx
+++ b/web/app/flows/details/StepGraph.tsx
@@ -28,7 +28,7 @@ interface StepNodeData extends Record<string, unknown> {
   model: StepGraphNode;
 }
 
-type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Completed' | 'Failed' | 'Pending' | 'Not used';
+type MethodStatus = 'Started' | 'Waiting' | 'Running' | 'Completed' | 'Failed' | 'Not started';
 
 function waitingCondition(node: StepGraphNode): Record<string, unknown> {
   const response = node.waitFor?.payload.response;
@@ -54,6 +54,11 @@ function channelNames(condition: Record<string, unknown>): string[] {
   });
 }
 
+function skipsWaitFor(node: StepGraphNode): boolean {
+  const options = node.active?.movement?.stepOptions;
+  return Boolean(options && typeof options === 'object' && (options as Record<string, unknown>).skipWaitFor === true);
+}
+
 function ConditionIcon({ type }: { type: 'timer' | 'channel' }) {
   if (type === 'timer') {
     return (
@@ -77,16 +82,15 @@ function waitForStatus(node: StepGraphNode): MethodStatus {
   if (node.waitFor?.type === 'StepWaitForFailed') return 'Failed';
   if (node.active?.phase === 'Waiting') return 'Waiting';
   if (node.waitFor) return 'Started';
-  if (node.transient) return 'Not used';
   if (node.active) return 'Running';
-  return 'Pending';
+  return 'Not started';
 }
 
 function executeStatus(node: StepGraphNode): MethodStatus {
   if (node.execute?.type === 'StepExecuteFailed') return 'Failed';
   if (node.execute) return 'Completed';
   if (node.active?.phase === 'Active' && node.waitFor) return 'Running';
-  return 'Pending';
+  return 'Not started';
 }
 
 function MethodSection({
@@ -131,6 +135,9 @@ function StepNodeLabel({
   const channelCount = conditionCount(condition, 'channelConditions');
   const channels = [...new Set(channelNames(condition))];
   const channelSummary = channels.length > 0 ? channels.join(', ') : `${channelCount} channel${channelCount === 1 ? '' : 's'}`;
+  const showWaitFor = Boolean(
+    node.waitFor || (!node.transient && !skipsWaitFor(node) && node.active && !node.execute),
+  );
   return (
     <div className="graph-step-label">
       <div className="graph-step-heading">
@@ -139,29 +146,31 @@ function StepNodeLabel({
         <code>{node.id}</code>
       </div>
       <div className="graph-methods">
-        <MethodSection
-          name="WaitFor"
-          status={waitForStatus(node)}
-          event={node.waitFor}
-          onSelect={onSelect}
-        >
-          {(timerCount > 0 || channelCount > 0) && (
-            <small className="graph-conditions">
-              {timerCount > 0 && (
-                <i title={`${timerCount} timer condition${timerCount === 1 ? '' : 's'}`}>
-                  <ConditionIcon type="timer" />
-                  {timerCount} timer{timerCount === 1 ? '' : 's'}
-                </i>
-              )}
-              {channelCount > 0 && (
-                <i title={channelSummary}>
-                  <ConditionIcon type="channel" />
-                  <span>{channelSummary}</span>
-                </i>
-              )}
-            </small>
-          )}
-        </MethodSection>
+        {showWaitFor && (
+          <MethodSection
+            name="WaitFor"
+            status={waitForStatus(node)}
+            event={node.waitFor}
+            onSelect={onSelect}
+          >
+            {(timerCount > 0 || channelCount > 0) && (
+              <small className="graph-conditions">
+                {timerCount > 0 && (
+                  <i title={`${timerCount} timer condition${timerCount === 1 ? '' : 's'}`}>
+                    <ConditionIcon type="timer" />
+                    {timerCount} timer{timerCount === 1 ? '' : 's'}
+                  </i>
+                )}
+                {channelCount > 0 && (
+                  <i title={channelSummary}>
+                    <ConditionIcon type="channel" />
+                    <span>{channelSummary}</span>
+                  </i>
+                )}
+              </small>
+            )}
+          </MethodSection>
+        )}
         <MethodSection
           name="Execute"
           status={executeStatus(node)}

--- a/web/app/flows/details/Timeline.tsx
+++ b/web/app/flows/details/Timeline.tsx
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { Link } from 'react-router-dom';
 import type { FlowHistoryEvent } from '@/lib/types';
 import { formatDate } from '@/lib/format';
@@ -18,6 +19,7 @@ import { eventTitle } from './EventDetails';
 interface StepLinkPath {
   id: string;
   label: string;
+  lane: number;
   path: string;
   duration: string;
   durationX: number;
@@ -69,6 +71,10 @@ export function Timeline({
   const eventDots = useRef(new Map<number, HTMLSpanElement>());
   const orderedEvents = useMemo(() => newestTimelineEvents(events), [events]);
   const stepLinks = useMemo(() => buildTimelineStepLinks(events), [events]);
+  const linkLaneCount = Math.max(1, ...stepLinks.map((link) => link.lane + 1));
+  const timelineStyle = {
+    '--timeline-link-rail-width': `${88 + (linkLaneCount - 1) * 48}px`,
+  } as CSSProperties;
   const [stepLinkLayout, setStepLinkLayout] = useState<StepLinkLayout>({ width: 0, height: 0, paths: [] });
   const updateStepLinks = useCallback(() => {
     const timeline = timelineRef.current;
@@ -84,11 +90,12 @@ export function Timeline({
       const executeX = executeRect.right - timelineRect.left + 2;
       const waitForY = waitForRect.top + waitForRect.height / 2 - timelineRect.top;
       const executeY = executeRect.top + executeRect.height / 2 - timelineRect.top;
-      const linkX = Math.max(waitForX, executeX) + 15;
+      const linkX = Math.max(waitForX, executeX) + 15 + link.lane * 48;
       const duration = formatElapsedDuration(link.conditionWaitDurationMs);
       return [{
         id: `${link.stepExecutionId}-${link.waitForEventId}-${link.executeEventId}`,
         label: `${link.stepExecutionId}: WaitForCondition started to Execute`,
+        lane: link.lane,
         path: `M ${waitForX} ${waitForY} H ${linkX} V ${executeY} H ${executeX}`,
         duration,
         durationX: linkX + 6,
@@ -127,7 +134,7 @@ export function Timeline({
           <h2>{events.length} events</h2>
         </div>
       </div>
-      <div className="timeline" ref={timelineRef}>
+      <div className="timeline" ref={timelineRef} style={timelineStyle}>
         {stepLinkLayout.paths.length > 0 && (
           <svg
             aria-hidden="true"
@@ -142,7 +149,7 @@ export function Timeline({
               </marker>
             </defs>
             {stepLinkLayout.paths.map((link) => (
-              <g key={link.id}>
+              <g data-step-execution-id={link.id} data-timeline-lane={link.lane} key={link.id}>
                 <path className="timeline-step-link" d={link.path} markerEnd="url(#timeline-step-arrow)">
                   <title>{link.label}</title>
                 </path>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -117,8 +117,8 @@ a {
 
 .brand-logo {
   position: absolute;
-  top: -4px;
-  left: -6px;
+  top: -7px;
+  left: -12px;
   width: 72px;
   height: 72px;
   max-width: none;
@@ -1597,6 +1597,10 @@ pre {
 .graph-methods {
   display: grid;
   grid-template-columns: 1fr 1fr;
+}
+
+.graph-methods > .graph-method:only-child {
+  grid-column: 1 / -1;
 }
 
 .graph-method {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1248,7 +1248,7 @@ pre {
 
 .timeline-row {
   display: grid;
-  grid-template-columns: 145px 88px minmax(0, 1fr);
+  grid-template-columns: 145px var(--timeline-link-rail-width, 88px) minmax(0, 1fr);
   cursor: pointer;
 }
 
@@ -1861,7 +1861,7 @@ pre {
   }
 
   .timeline-row {
-    grid-template-columns: 74px minmax(0, 1fr);
+    grid-template-columns: calc(var(--timeline-link-rail-width, 88px) - 14px) minmax(0, 1fr);
   }
 
   .timeline-time {

--- a/web/lib/graph.test.ts
+++ b/web/lib/graph.test.ts
@@ -7,15 +7,16 @@
 // SPDX-License-Identifier: LicenseRef-Super-Durable-1.0
 
 import { describe, expect, it } from 'vitest';
-import { buildStepGraph } from './graph';
+import { buildStepGraph, END_NODE_ID } from './graph';
 import type { FlowHistoryEvent } from './types';
 
 function event(
   eventId: number,
   type: FlowHistoryEvent['type'],
   execution: Record<string, unknown> = {},
+  payload: Record<string, unknown> = {},
 ): FlowHistoryEvent {
-  return { eventId, eventTime: null, type, payload: { execution } };
+  return { eventId, eventTime: null, type, payload: { ...payload, execution } };
 }
 
 describe('step graph', () => {
@@ -77,5 +78,34 @@ describe('step graph', () => {
       source: '__rpc/approve',
       target: 'Approval-1',
     });
+  });
+
+  it('connects only the step with a close decision to the terminal node', () => {
+    const graph = buildStepGraph([
+      event(1, 'StepWaitForCompleted', {
+        stepExecutionId: 'trial-1',
+        fromStepExecutionId: 'initialize-1',
+        stepType: 'trial',
+      }),
+      event(2, 'StepWaitForCompleted', {
+        stepExecutionId: 'cancel-1',
+        fromStepExecutionId: 'initialize-1',
+        stepType: 'cancel',
+      }),
+      event(3, 'StepExecuteCompleted', {
+        stepExecutionId: 'cancel-1',
+        fromStepExecutionId: 'initialize-1',
+        stepType: 'cancel',
+      }, {
+        response: { stepDecision: { closeDecision: { closeDecisionType: 3 } } },
+      }),
+      event(4, 'FlowClosed'),
+    ]);
+
+    expect(graph.edges.filter((edge) => edge.target === END_NODE_ID)).toEqual([{
+      id: 'cancel-1->__end__',
+      source: 'cancel-1',
+      target: '__end__',
+    }]);
   });
 });

--- a/web/lib/graph.ts
+++ b/web/lib/graph.ts
@@ -44,6 +44,7 @@ export function buildStepGraph(
   activeSteps: ActiveStepExecution[] = [],
 ): { nodes: StepGraphNode[]; edges: StepGraphEdge[] } {
   const nodes = new Map<string, StepGraphNode>();
+  const closingStepExecutionIDs = new Set<string>();
   nodes.set(START_NODE_ID, {
     id: START_NODE_ID,
     label: 'Flow start',
@@ -61,6 +62,9 @@ export function buildStepGraph(
     const failed = event.type.endsWith('Failed');
     const waitFor = event.type.startsWith('StepWaitFor') ? event : existing?.waitFor;
     const execute = event.type.startsWith('StepExecute') ? event : existing?.execute;
+    if (event.type === 'StepExecuteCompleted' && hasCloseDecision(event)) {
+      closingStepExecutionIDs.add(id);
+    }
     nodes.set(id, {
       id,
       label: stringField(info.stepType) || id,
@@ -122,13 +126,23 @@ export function buildStepGraph(
   }
 
   if (closed) {
-    const stepIdsWithChildren = new Set(edges.map((edge) => edge.source));
-    for (const node of nodes.values()) {
-      if (node.kind === 'step' && !stepIdsWithChildren.has(node.id)) {
-        edges.push({ id: `${node.id}->${END_NODE_ID}`, source: node.id, target: END_NODE_ID });
-      }
+    for (const stepExecutionID of closingStepExecutionIDs) {
+      edges.push({
+        id: `${stepExecutionID}->${END_NODE_ID}`,
+        source: stepExecutionID,
+        target: END_NODE_ID,
+      });
     }
   }
 
   return { nodes: [...nodes.values()], edges };
+}
+
+function hasCloseDecision(event: FlowHistoryEvent): boolean {
+  const response = event.payload.response;
+  if (!response || typeof response !== 'object') return false;
+  const stepDecision = (response as Record<string, unknown>).stepDecision;
+  if (!stepDecision || typeof stepDecision !== 'object') return false;
+  const closeDecision = (stepDecision as Record<string, unknown>).closeDecision;
+  return Boolean(closeDecision && typeof closeDecision === 'object');
 }

--- a/web/lib/semantic.ts
+++ b/web/lib/semantic.ts
@@ -14,11 +14,11 @@ function enumLabel(value: unknown, labels: Record<string, string>): string {
 export function durabilityLabel(value: unknown): string {
   return enumLabel(value, {
     0: 'Unspecified',
-    1: 'Synchronous',
-    2: 'Asynchronous',
+    1: 'sync',
+    2: 'async',
     STEP_DURABILITY_UNSPECIFIED: 'Unspecified',
-    STEP_DURABILITY_SYNC: 'Synchronous',
-    STEP_DURABILITY_ASYNC: 'Asynchronous',
+    STEP_DURABILITY_SYNC: 'sync',
+    STEP_DURABILITY_ASYNC: 'async',
   });
 }
 

--- a/web/lib/timeline.test.ts
+++ b/web/lib/timeline.test.ts
@@ -40,8 +40,27 @@ describe('timeline', () => {
       event(20, 'StepExecuteFailed', 'A-1'),
     ]);
     expect(links).toEqual([
-      { stepExecutionId: 'A-1', waitForEventId: 10, executeEventId: 20, conditionWaitDurationMs: null },
-      { stepExecutionId: 'B-1', waitForEventId: 30, executeEventId: 40, conditionWaitDurationMs: null },
+      { stepExecutionId: 'A-1', waitForEventId: 10, executeEventId: 20, conditionWaitDurationMs: null, lane: 0 },
+      { stepExecutionId: 'B-1', waitForEventId: 30, executeEventId: 40, conditionWaitDurationMs: null, lane: 0 },
+    ]);
+  });
+
+  it('separates overlapping step executions and reuses lanes afterward', () => {
+    const links = buildTimelineStepLinks([
+      event(9, 'StepWaitForCompleted', 'A-1'),
+      event(10, 'StepWaitForCompleted', 'B-1'),
+      event(11, 'StepWaitForCompleted', 'C-1'),
+      event(22, 'StepExecuteCompleted', 'A-1'),
+      event(28, 'StepExecuteCompleted', 'B-1'),
+      event(30, 'StepExecuteCompleted', 'C-1'),
+      event(40, 'StepWaitForCompleted', 'D-1'),
+      event(50, 'StepExecuteCompleted', 'D-1'),
+    ]);
+    expect(links.map(({ stepExecutionId, lane }) => ({ stepExecutionId, lane }))).toEqual([
+      { stepExecutionId: 'A-1', lane: 0 },
+      { stepExecutionId: 'B-1', lane: 1 },
+      { stepExecutionId: 'C-1', lane: 2 },
+      { stepExecutionId: 'D-1', lane: 0 },
     ]);
   });
 

--- a/web/lib/timeline.ts
+++ b/web/lib/timeline.ts
@@ -13,6 +13,7 @@ export interface TimelineStepLink {
   waitForEventId: number;
   executeEventId: number;
   conditionWaitDurationMs: number | null;
+  lane: number;
 }
 
 export function newestTimelineEvents(events: FlowHistoryEvent[]): FlowHistoryEvent[] {
@@ -21,7 +22,7 @@ export function newestTimelineEvents(events: FlowHistoryEvent[]): FlowHistoryEve
 
 export function buildTimelineStepLinks(events: FlowHistoryEvent[]): TimelineStepLink[] {
   const pendingWaitFor = new Map<string, FlowHistoryEvent>();
-  const links: TimelineStepLink[] = [];
+  const links: Omit<TimelineStepLink, 'lane'>[] = [];
   const chronologicalEvents = [...events].sort((left, right) => left.eventId - right.eventId);
 
   for (const event of chronologicalEvents) {
@@ -42,7 +43,7 @@ export function buildTimelineStepLinks(events: FlowHistoryEvent[]): TimelineStep
     });
     pendingWaitFor.delete(stepExecutionId);
   }
-  return links;
+  return assignTimelineStepLinkLanes(links);
 }
 
 export function formatElapsedDuration(milliseconds: number | null): string {
@@ -80,4 +81,18 @@ function elapsedMilliseconds(start: string | null, end: string | null): number |
   const endMs = Date.parse(end);
   if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
   return Math.max(0, endMs - startMs);
+}
+
+function assignTimelineStepLinkLanes(
+  links: Omit<TimelineStepLink, 'lane'>[],
+): TimelineStepLink[] {
+  const laneEndEventIds: number[] = [];
+  return [...links]
+    .sort((left, right) => left.waitForEventId - right.waitForEventId)
+    .map((link) => {
+      let lane = laneEndEventIds.findIndex((endEventId) => endEventId < link.waitForEventId);
+      if (lane < 0) lane = laneEndEventIds.length;
+      laneEndEventIds[lane] = link.executeEventId;
+      return { ...link, lane };
+    });
 }


### PR DESCRIPTION
## Summary

- separate concurrent WaitFor-to-Execute timeline links into distinct lanes with duration labels
- hide nonexistent WaitFor methods, label unstarted Execute methods accurately, and connect Flow closed only to explicit close decisions
- reuse structured semantic event details for run input, simplify close results, shorten durability labels, and center the header logo

## Rationale

The flow views previously implied relationships and states that were not present in Dex history. Concurrent timeline links overlapped, execute-only steps showed a pending WaitFor, every leaf appeared to close the flow, and overview payloads exposed hard-to-read proto JSON.

## User impact

Timeline and Step Graph now reflect Dex semantics more accurately. Run inputs and close results are easier to read, and the compact visual labels and corrected logo alignment improve scanability.

## Validation

- `cd web && npm run check`
- `cd web && npm run build`
- manually verified subscription and money-transfer runs against a local Dex server
