### PR TITLE
Default run details to Timeline

### DIFF
--- a/web/app/flows/RunDetailsPage.tsx
+++ b/web/app/flows/RunDetailsPage.tsx
@@ -40,7 +40,7 @@ export function RunDetailsPage({ flowId, runId }: { flowId: string; runId: strin
   const [state, setState] = useState<FlowState | null>(null);
   const [nextPageToken, setNextPageToken] = useState('');
   const [nextInternalEventId, setNextInternalEventId] = useState(0);
-  const [tab, setTab] = useState<RunTab>('overview');
+  const [tab, setTab] = useState<RunTab>('timeline');
   const [selectedEvent, setSelectedEvent] = useState<FlowHistoryEvent | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);


### PR DESCRIPTION
## Summary

- open Run details on Timeline by default
- preserve Overview and Step graph as selectable tabs

## Verification

- `npm run check`
- `npm run build`
- `make copyright-check`
- browser verification against the local Dex Web preview
