### PR TITLE
Default Go SDK flow and step type names

### DIFF
--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -1556,7 +1556,7 @@ Phase 1 owns these conceptual files under `sdk-go/dex/`:
 
 ```text
 flow.go             Flow and persistence declaration
-step.go             Step, StepDef, None, NoWaitFor, StepDefaults
+step.go             Step, StepDef, None, defaults, and NoWaitFor
 context.go          Context, invocation metadata, locals, and events
 attribute.go        Attribute, AttributeMap, indexing, invocation operations
 channel.go          Channel, ChannelMap, publish, size, bounded conditions
@@ -1583,7 +1583,7 @@ type Flow interface {
 }
 ```
 
-Embedding `DefaultFlowType` makes `GetFlowType` return empty, selecting the
+Embedding `FlowDefaults` makes `GetFlowType` return empty, selecting the
 pointer-stripped package-qualified Go type such as `orders.OrderFlow`. An
 explicit non-empty result overrides that default. Registration of a flow
 together with its heterogeneous steps and RPCs belongs to Phase 3.
@@ -1624,8 +1624,12 @@ type DefaultStepOptions struct {
 	DefaultStepType
 }
 
-type StepDefaults[IN any] struct {
+type StepDefaults struct {
 	DefaultStepOptions
+}
+
+type StepDefaultsNoWaitFor[IN any] struct {
+	StepDefaults
 	NoWaitFor[IN]
 }
 
@@ -1649,16 +1653,17 @@ payload. Applications pass `nil`; the unexported pointed-to type prevents
 constructing a non-nil payload and preserves compile-time rejection unlike
 `any`.
 
-An Execute-only step embeds `StepDefaults[IN]`, or embeds `NoWaitFor[IN]` and
-implements `GetStepOptions` itself. `NoWaitFor` supplies the interface method
-and carries an unexported marker. Phase 3 registration detects that marker and
-sets `skip_wait_for`; it never calls the supplied `WaitFor` method. There is no
-public `SkipWaitFor` field.
+An Execute-only step embeds `StepDefaultsNoWaitFor[IN]`, or embeds
+`NoWaitFor[IN]` and implements its type and options methods. `NoWaitFor`
+supplies the interface method and carries an unexported marker. Phase 3
+registration detects that marker and sets `skip_wait_for`; it never calls the
+supplied `WaitFor` method. There is no public `SkipWaitFor` field.
 
-A step that waits implements `WaitFor` and may implement `GetStepOptions`
-directly. It must not embed `NoWaitFor` or `StepDefaults`. Embedding
-`DefaultStepOptions` also supplies the default package-qualified step type;
-an explicit non-empty `GetStepType` result overrides it.
+A waiting step embeds `StepDefaults` and implements `WaitFor` and `Execute`.
+`StepDefaults` contains only `DefaultStepOptions`, so it never supplies or
+skips `WaitFor`. A custom-options waiting step embeds `DefaultStepType` and
+implements `GetStepOptions` directly. An explicit non-empty `GetStepType`
+result overrides the default package-qualified step type.
 
 `DefineStep` and `DefineStartStep` retain the handler's input type while
 building the heterogeneous `GetSteps` result. Phase 3 validates duplicate step
@@ -1672,7 +1677,7 @@ Example:
 
 ```go
 type ApproveOrderStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (ApproveOrderStep) WaitFor(
@@ -1709,7 +1714,7 @@ var ApproveOrder = ApproveOrderStep{}
 var _ dex.Step[ApproveOrderInput] = ApproveOrder
 
 type ShipOrderStep struct {
-	dex.StepDefaults[ShipOrderInput]
+	dex.StepDefaultsNoWaitFor[ShipOrderInput]
 }
 
 func (ShipOrderStep) Execute(
@@ -2646,7 +2651,7 @@ var (
 )
 
 type WaitForCommandStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (WaitForCommandStep) WaitFor(
@@ -2705,7 +2710,7 @@ var WaitForCommand = WaitForCommandStep{}
 var _ dex.Step[OrderInput] = WaitForCommand
 
 type OrderFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {
@@ -2749,8 +2754,8 @@ Add SDK external-package tests (`package dex_test`) for these scenarios:
 
 1. A package can declare a flow, heterogeneous typed steps, attributes,
    channels, and RPCs without importing `dexpb`.
-2. Waiting and Execute-only handlers satisfy the same `Step[IN]`; the latter
-   embeds `NoWaitFor[IN]`.
+2. Waiting and Execute-only handlers satisfy the same `Step[IN]`; the former
+   embeds `StepDefaults` and the latter embeds `StepDefaultsNoWaitFor[IN]`.
 3. `None` preserves typed Step, RPC, and Channel declarations without accepting
    arbitrary payloads.
 4. `DefineStep`, `DefineStartStep`, `GoTo`, `MovementOf`, and `GoToMulti`
@@ -2808,7 +2813,7 @@ Temporal-backed.
 - Keep this plan linked from [`docs/README.md`](../../README.md).
 - Keep [`sdk-go/README.md`](../../../sdk-go/README.md) aligned with the
   authoring and value-codec contracts. Cover the single `Step[IN]`
-  interface, embedded `NoWaitFor[IN]`, Flow method RPCs, close decisions, typed
+  interface, step defaults, Flow method RPCs, close decisions, typed
   attributes/channels, untyped step-execution locals and events, strongly typed
   channel results, timer-fired helpers, `WaitForMethodFailed`, and RPC-only
   channel size.

--- a/docs/design/plan/go-sdk-rewrite.md
+++ b/docs/design/plan/go-sdk-rewrite.md
@@ -223,6 +223,12 @@ Attribute names are unique within a flow's attribute namespace, and channel
 names are unique within its channel namespace. An attribute and channel may
 share a name because the server stores them separately.
 
+Flow and step names use a non-empty `GetFlowType` or `GetStepType` override.
+Otherwise the SDK removes leading pointer markers from
+`reflect.TypeOf(value).String()`, producing names such as
+`orders.OrderFlow` and `orders.initializeStep`. Registration,
+movements, failure targets, Worker dispatch, and StartFlow share this resolver.
+
 All lookup APIs remain private. Phase 4 receives immutable descriptors rather
 than raw maps and is responsible for converting a missing lookup into the
 appropriate WorkerService error.
@@ -232,7 +238,7 @@ appropriate WorkerService error.
 `NewRegistry` evaluates each supplied Flow once. It rejects:
 
 - nil and typed-nil Flow values;
-- empty or duplicate durable flow types;
+- duplicate final durable flow types;
 - nil persistence definitions;
 - empty or duplicate attribute names;
 - empty or duplicate channel names;
@@ -285,7 +291,7 @@ and after calling the adapter.
 
 Registration rejects:
 
-- an empty or duplicate durable step type within one flow;
+- a duplicate final durable step type within one flow;
 - a zero `StepDef`, nil handler, or typed-nil handler;
 - more than one `DefineStartStep` entry;
 - invalid step defaults or attribute locks, reporting the first illegal step
@@ -1531,8 +1537,8 @@ N/A: no in-repo web UI.
 ### Design rules
 
 1. Application code imports `dex`, not `gen/dexpb`.
-2. Persisted flow, step, attribute, and channel names are explicit strings.
-   RPC names come from registered Flow method names.
+2. Flow and step names default to pointer-stripped package-qualified Go types.
+   Attributes and channels use explicit strings; RPCs use Flow method names.
 3. Typed attributes and channels are immutable and safe as package variables.
 4. Methods that use invocation state take `Context` explicitly. Flow, step, and
    RPC implementations must not retain a current invocation.
@@ -1565,7 +1571,7 @@ errors.go           public error model
 This is a logical split, not permission to add runtime implementations during
 Phase 1.
 
-### Flow and explicit durable names
+### Flow and durable names
 
 Application code implements a minimal flow interface:
 
@@ -1577,8 +1583,10 @@ type Flow interface {
 }
 ```
 
-`GetFlowType` must return a non-empty, explicit durable name. Registration of a
-flow together with its heterogeneous steps and RPCs belongs to Phase 3.
+Embedding `DefaultFlowType` makes `GetFlowType` return empty, selecting the
+pointer-stripped package-qualified Go type such as `orders.OrderFlow`. An
+explicit non-empty result overrides that default. Registration of a flow
+together with its heterogeneous steps and RPCs belongs to Phase 3.
 `GetSteps` supplies every step through an opaque `StepDef`. Generic handler
 adapters remain internal implementation details, not public Phase 1 API.
 
@@ -1610,7 +1618,11 @@ func DefineStartStep[IN any](step Step[IN]) StepDef
 
 type NoWaitFor[IN any] struct{}
 
-type DefaultStepOptions struct{}
+type DefaultStepType struct{}
+
+type DefaultStepOptions struct {
+	DefaultStepType
+}
 
 type StepDefaults[IN any] struct {
 	DefaultStepOptions
@@ -1626,6 +1638,10 @@ func (NoWaitFor[IN]) noWaitFor() {}
 func (DefaultStepOptions) GetStepOptions() *StepOptions {
 	return nil
 }
+
+func (DefaultStepType) GetStepType() string {
+	return ""
+}
 ```
 
 `None` is a pointer alias for a Step, RPC, or Channel with no application
@@ -1640,8 +1656,9 @@ sets `skip_wait_for`; it never calls the supplied `WaitFor` method. There is no
 public `SkipWaitFor` field.
 
 A step that waits implements `WaitFor` and may implement `GetStepOptions`
-directly. It must not embed `NoWaitFor` or `StepDefaults`. `GetStepType` must
-return a non-empty, explicit durable name.
+directly. It must not embed `NoWaitFor` or `StepDefaults`. Embedding
+`DefaultStepOptions` also supplies the default package-qualified step type;
+an explicit non-empty `GetStepType` result overrides it.
 
 `DefineStep` and `DefineStartStep` retain the handler's input type while
 building the heterogeneous `GetSteps` result. Phase 3 validates duplicate step
@@ -1656,10 +1673,6 @@ Example:
 ```go
 type ApproveOrderStep struct {
 	dex.DefaultStepOptions
-}
-
-func (ApproveOrderStep) GetStepType() string {
-	return "approve-order"
 }
 
 func (ApproveOrderStep) WaitFor(
@@ -1697,10 +1710,6 @@ var _ dex.Step[ApproveOrderInput] = ApproveOrder
 
 type ShipOrderStep struct {
 	dex.StepDefaults[ShipOrderInput]
-}
-
-func (ShipOrderStep) GetStepType() string {
-	return "ship-order"
 }
 
 func (ShipOrderStep) Execute(
@@ -2640,10 +2649,6 @@ type WaitForCommandStep struct {
 	dex.DefaultStepOptions
 }
 
-func (WaitForCommandStep) GetStepType() string {
-	return "wait-for-command"
-}
-
 func (WaitForCommandStep) WaitFor(
 	ctx dex.Context,
 	input OrderInput,
@@ -2699,10 +2704,8 @@ func (WaitForCommandStep) Execute(
 var WaitForCommand = WaitForCommandStep{}
 var _ dex.Step[OrderInput] = WaitForCommand
 
-type OrderFlow struct{}
-
-func (OrderFlow) GetFlowType() string {
-	return "order"
+type OrderFlow struct {
+	dex.DefaultFlowType
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {

--- a/docs/wiki/Basic-concepts-overview.md
+++ b/docs/wiki/Basic-concepts-overview.md
@@ -145,7 +145,7 @@ class UserSignupWorkflow(ObjectWorkflow):
 
 #### Golang
 
-Go applications implement `dex.Flow` and typed `dex.Step[IN]` values. Execute-only Steps embed `dex.StepDefaults[IN]`; waiting Steps implement `WaitFor`. Exported Flow methods matching `dex.RPC[IN, OUT]` are registered automatically.
+Go applications implement `dex.Flow` and typed `dex.Step[IN]` values. Waiting Steps embed `dex.StepDefaults` and implement `WaitFor`; execute-only Steps embed `dex.StepDefaultsNoWaitFor[IN]`. Exported Flow methods matching `dex.RPC[IN, OUT]` are registered automatically.
 
 This is an [example](../../examples/go/workflows/microservices/workflow.go) of a Go Flow definition:
 
@@ -156,6 +156,7 @@ var (
 )
 
 type OrchestrationFlow struct {
+	dex.FlowDefaults
 	service service.MyService
 }
 

--- a/examples/go/workflows/engagement/workflow.go
+++ b/examples/go/workflows/engagement/workflow.go
@@ -47,7 +47,7 @@ var (
 )
 
 type EngagementFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 	service service.MyService
 }
 
@@ -181,7 +181,7 @@ func updateStatus(ctx dex.Context, status Status, note string) error {
 }
 
 type initializeStep struct {
-	dex.StepDefaults[EngagementInput]
+	dex.StepDefaultsNoWaitFor[EngagementInput]
 }
 
 func (initializeStep) Execute(
@@ -211,7 +211,7 @@ func (initializeStep) Execute(
 }
 
 type processTimeoutStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 
@@ -247,7 +247,7 @@ func (step processTimeoutStep) Execute(
 }
 
 type reminderStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 
@@ -291,7 +291,7 @@ func (step reminderStep) Execute(
 }
 
 type notifyExternalSystemStep struct {
-	dex.StepDefaults[Status]
+	dex.StepDefaultsNoWaitFor[Status]
 	service service.MyService
 }
 

--- a/examples/go/workflows/engagement/workflow.go
+++ b/examples/go/workflows/engagement/workflow.go
@@ -47,15 +47,12 @@ var (
 )
 
 type EngagementFlow struct {
+	dex.DefaultFlowType
 	service service.MyService
 }
 
 func NewEngagementFlow(applicationService service.MyService) *EngagementFlow {
 	return &EngagementFlow{service: applicationService}
-}
-
-func (flow *EngagementFlow) GetFlowType() string {
-	return "engagement"
 }
 
 func (flow *EngagementFlow) GetSteps() []dex.StepDef {
@@ -187,10 +184,6 @@ type initializeStep struct {
 	dex.StepDefaults[EngagementInput]
 }
 
-func (initializeStep) GetStepType() string {
-	return "initialize"
-}
-
 func (initializeStep) Execute(
 	ctx dex.Context,
 	input EngagementInput,
@@ -220,10 +213,6 @@ func (initializeStep) Execute(
 type processTimeoutStep struct {
 	dex.DefaultStepOptions
 	service service.MyService
-}
-
-func (processTimeoutStep) GetStepType() string {
-	return "process-timeout"
 }
 
 func (processTimeoutStep) WaitFor(
@@ -260,10 +249,6 @@ func (step processTimeoutStep) Execute(
 type reminderStep struct {
 	dex.DefaultStepOptions
 	service service.MyService
-}
-
-func (reminderStep) GetStepType() string {
-	return "reminder"
 }
 
 func (reminderStep) WaitFor(
@@ -308,10 +293,6 @@ func (step reminderStep) Execute(
 type notifyExternalSystemStep struct {
 	dex.StepDefaults[Status]
 	service service.MyService
-}
-
-func (notifyExternalSystemStep) GetStepType() string {
-	return "notify-external-system"
 }
 
 func (step notifyExternalSystemStep) Execute(

--- a/examples/go/workflows/microservices/workflow.go
+++ b/examples/go/workflows/microservices/workflow.go
@@ -33,7 +33,7 @@ var (
 )
 
 type OrchestrationFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 	service service.MyService
 }
 
@@ -72,7 +72,7 @@ func (*OrchestrationFlow) Swap(
 }
 
 type callAPI1Step struct {
-	dex.StepDefaults[string]
+	dex.StepDefaultsNoWaitFor[string]
 	service service.MyService
 }
 
@@ -91,7 +91,7 @@ func (step callAPI1Step) Execute(
 }
 
 type callAPI2Step struct {
-	dex.StepDefaults[dex.None]
+	dex.StepDefaultsNoWaitFor[dex.None]
 	service service.MyService
 }
 
@@ -108,7 +108,7 @@ func (step callAPI2Step) Execute(
 }
 
 type callAPI3Step struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 
@@ -138,7 +138,7 @@ func (step callAPI3Step) Execute(
 }
 
 type callAPI4Step struct {
-	dex.StepDefaults[dex.None]
+	dex.StepDefaultsNoWaitFor[dex.None]
 	service service.MyService
 }
 

--- a/examples/go/workflows/microservices/workflow.go
+++ b/examples/go/workflows/microservices/workflow.go
@@ -33,15 +33,12 @@ var (
 )
 
 type OrchestrationFlow struct {
+	dex.DefaultFlowType
 	service service.MyService
 }
 
 func NewOrchestrationFlow(applicationService service.MyService) *OrchestrationFlow {
 	return &OrchestrationFlow{service: applicationService}
-}
-
-func (*OrchestrationFlow) GetFlowType() string {
-	return "microservice-orchestration"
 }
 
 func (flow *OrchestrationFlow) GetSteps() []dex.StepDef {
@@ -79,10 +76,6 @@ type callAPI1Step struct {
 	service service.MyService
 }
 
-func (callAPI1Step) GetStepType() string {
-	return "call-api-1"
-}
-
 func (step callAPI1Step) Execute(
 	ctx dex.Context,
 	input string,
@@ -102,10 +95,6 @@ type callAPI2Step struct {
 	service service.MyService
 }
 
-func (callAPI2Step) GetStepType() string {
-	return "call-api-2"
-}
-
 func (step callAPI2Step) Execute(
 	ctx dex.Context,
 	_ dex.None,
@@ -121,10 +110,6 @@ func (step callAPI2Step) Execute(
 type callAPI3Step struct {
 	dex.DefaultStepOptions
 	service service.MyService
-}
-
-func (callAPI3Step) GetStepType() string {
-	return "call-api-3"
 }
 
 func (callAPI3Step) WaitFor(
@@ -155,10 +140,6 @@ func (step callAPI3Step) Execute(
 type callAPI4Step struct {
 	dex.StepDefaults[dex.None]
 	service service.MyService
-}
-
-func (callAPI4Step) GetStepType() string {
-	return "call-api-4"
 }
 
 func (step callAPI4Step) Execute(

--- a/examples/go/workflows/moneytransfer/workflow.go
+++ b/examples/go/workflows/moneytransfer/workflow.go
@@ -36,7 +36,7 @@ type TransferRequest struct {
 }
 
 type MoneyTransferFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 	service service.MyService
 }
 
@@ -60,7 +60,7 @@ func (*MoneyTransferFlow) GetPersistenceSchema() dex.PersistenceSchema {
 }
 
 type checkBalanceStep struct {
-	dex.StepDefaults[TransferRequest]
+	dex.StepDefaultsNoWaitFor[TransferRequest]
 	service service.MyService
 }
 

--- a/examples/go/workflows/moneytransfer/workflow.go
+++ b/examples/go/workflows/moneytransfer/workflow.go
@@ -36,15 +36,12 @@ type TransferRequest struct {
 }
 
 type MoneyTransferFlow struct {
+	dex.DefaultFlowType
 	service service.MyService
 }
 
 func NewMoneyTransferFlow(applicationService service.MyService) *MoneyTransferFlow {
 	return &MoneyTransferFlow{service: applicationService}
-}
-
-func (*MoneyTransferFlow) GetFlowType() string {
-	return "money-transfer"
 }
 
 func (flow *MoneyTransferFlow) GetSteps() []dex.StepDef {
@@ -67,10 +64,6 @@ type checkBalanceStep struct {
 	service service.MyService
 }
 
-func (checkBalanceStep) GetStepType() string {
-	return "check-balance"
-}
-
 func (step checkBalanceStep) Execute(
 	_ dex.Context,
 	request TransferRequest,
@@ -82,12 +75,9 @@ func (step checkBalanceStep) Execute(
 }
 
 type createDebitMemoStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[TransferRequest]
 	service service.MyService
-}
-
-func (createDebitMemoStep) GetStepType() string {
-	return "create-debit-memo"
 }
 
 func (createDebitMemoStep) GetStepOptions() *dex.StepOptions {
@@ -109,12 +99,9 @@ func (step createDebitMemoStep) Execute(
 }
 
 type debitStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[TransferRequest]
 	service service.MyService
-}
-
-func (debitStep) GetStepType() string {
-	return "debit"
 }
 
 func (debitStep) GetStepOptions() *dex.StepOptions {
@@ -132,12 +119,9 @@ func (step debitStep) Execute(
 }
 
 type createCreditMemoStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[TransferRequest]
 	service service.MyService
-}
-
-func (createCreditMemoStep) GetStepType() string {
-	return "create-credit-memo"
 }
 
 func (createCreditMemoStep) GetStepOptions() *dex.StepOptions {
@@ -159,12 +143,9 @@ func (step createCreditMemoStep) Execute(
 }
 
 type creditStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[TransferRequest]
 	service service.MyService
-}
-
-func (creditStep) GetStepType() string {
-	return "credit"
 }
 
 func (creditStep) GetStepOptions() *dex.StepOptions {
@@ -187,12 +168,9 @@ func (step creditStep) Execute(
 }
 
 type compensateStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[TransferRequest]
 	service service.MyService
-}
-
-func (compensateStep) GetStepType() string {
-	return "compensate"
 }
 
 func (compensateStep) GetStepOptions() *dex.StepOptions {

--- a/examples/go/workflows/polling/workflow.go
+++ b/examples/go/workflows/polling/workflow.go
@@ -35,7 +35,7 @@ var (
 )
 
 type PollingFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 	service service.MyService
 }
 
@@ -63,7 +63,7 @@ func (*PollingFlow) GetPersistenceSchema() dex.PersistenceSchema {
 }
 
 type initializeStep struct {
-	dex.StepDefaults[int]
+	dex.StepDefaultsNoWaitFor[int]
 }
 
 func (initializeStep) Execute(
@@ -77,7 +77,7 @@ func (initializeStep) Execute(
 }
 
 type waitForTasksStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (waitForTasksStep) WaitFor(
@@ -99,7 +99,7 @@ func (waitForTasksStep) Execute(
 }
 
 type pollStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 

--- a/examples/go/workflows/polling/workflow.go
+++ b/examples/go/workflows/polling/workflow.go
@@ -35,15 +35,12 @@ var (
 )
 
 type PollingFlow struct {
+	dex.DefaultFlowType
 	service service.MyService
 }
 
 func NewPollingFlow(applicationService service.MyService) *PollingFlow {
 	return &PollingFlow{service: applicationService}
-}
-
-func (*PollingFlow) GetFlowType() string {
-	return "polling"
 }
 
 func (flow *PollingFlow) GetSteps() []dex.StepDef {
@@ -69,10 +66,6 @@ type initializeStep struct {
 	dex.StepDefaults[int]
 }
 
-func (initializeStep) GetStepType() string {
-	return "initialize"
-}
-
 func (initializeStep) Execute(
 	_ dex.Context,
 	maximumPolls int,
@@ -85,10 +78,6 @@ func (initializeStep) Execute(
 
 type waitForTasksStep struct {
 	dex.DefaultStepOptions
-}
-
-func (waitForTasksStep) GetStepType() string {
-	return "wait-for-tasks"
 }
 
 func (waitForTasksStep) WaitFor(
@@ -112,10 +101,6 @@ func (waitForTasksStep) Execute(
 type pollStep struct {
 	dex.DefaultStepOptions
 	service service.MyService
-}
-
-func (pollStep) GetStepType() string {
-	return "poll-task-c"
 }
 
 func (pollStep) WaitFor(

--- a/examples/go/workflows/subscription/workflow.go
+++ b/examples/go/workflows/subscription/workflow.go
@@ -51,15 +51,12 @@ type Customer struct {
 }
 
 type SubscriptionFlow struct {
+	dex.DefaultFlowType
 	service service.MyService
 }
 
 func NewSubscriptionFlow(applicationService service.MyService) *SubscriptionFlow {
 	return &SubscriptionFlow{service: applicationService}
-}
-
-func (*SubscriptionFlow) GetFlowType() string {
-	return "subscription"
 }
 
 func (flow *SubscriptionFlow) GetSteps() []dex.StepDef {
@@ -94,10 +91,6 @@ type initializeStep struct {
 	dex.StepDefaults[Customer]
 }
 
-func (initializeStep) GetStepType() string {
-	return "initialize"
-}
-
 func (initializeStep) Execute(
 	ctx dex.Context,
 	customer Customer,
@@ -111,10 +104,6 @@ func (initializeStep) Execute(
 type trialStep struct {
 	dex.DefaultStepOptions
 	service service.MyService
-}
-
-func (trialStep) GetStepType() string {
-	return "trial"
 }
 
 func (step trialStep) WaitFor(
@@ -143,10 +132,6 @@ const subscriptionOverKey = "subscription-over"
 type chargeCurrentBillStep struct {
 	dex.DefaultStepOptions
 	service service.MyService
-}
-
-func (chargeCurrentBillStep) GetStepType() string {
-	return "charge-current-bill"
 }
 
 func (chargeCurrentBillStep) WaitFor(
@@ -198,10 +183,6 @@ type cancelStep struct {
 	service service.MyService
 }
 
-func (cancelStep) GetStepType() string {
-	return "cancel"
-}
-
 func (cancelStep) WaitFor(
 	dex.Context,
 	dex.None,
@@ -222,10 +203,6 @@ func (step cancelStep) Execute(
 
 type updateChargeAmountStep struct {
 	dex.DefaultStepOptions
-}
-
-func (updateChargeAmountStep) GetStepType() string {
-	return "update-charge-amount"
 }
 
 func (updateChargeAmountStep) WaitFor(

--- a/examples/go/workflows/subscription/workflow.go
+++ b/examples/go/workflows/subscription/workflow.go
@@ -51,7 +51,7 @@ type Customer struct {
 }
 
 type SubscriptionFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 	service service.MyService
 }
 
@@ -88,7 +88,7 @@ func (*SubscriptionFlow) Describe(
 }
 
 type initializeStep struct {
-	dex.StepDefaults[Customer]
+	dex.StepDefaultsNoWaitFor[Customer]
 }
 
 func (initializeStep) Execute(
@@ -102,7 +102,7 @@ func (initializeStep) Execute(
 }
 
 type trialStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 
@@ -130,7 +130,7 @@ func (trialStep) Execute(
 const subscriptionOverKey = "subscription-over"
 
 type chargeCurrentBillStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 
@@ -179,7 +179,7 @@ func (step chargeCurrentBillStep) Execute(
 }
 
 type cancelStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 	service service.MyService
 }
 
@@ -202,7 +202,7 @@ func (step cancelStep) Execute(
 }
 
 type updateChargeAmountStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (updateChargeAmountStep) WaitFor(

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -25,7 +25,7 @@ var (
 )
 
 type WaitForCommandStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (WaitForCommandStep) WaitFor(
@@ -61,7 +61,7 @@ func (WaitForCommandStep) Execute(
 var WaitForCommand = WaitForCommandStep{}
 
 type OrderFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {
@@ -81,7 +81,7 @@ func (OrderFlow) GetPersistenceSchema() dex.PersistenceSchema {
 Flows use `dex.DefineStartStep` for at most one starting step and
 `dex.DefineStep` for every non-starting step.
 
-Execute-only steps embed `dex.StepDefaults[IN]`. Step transitions use
+Execute-only steps embed `dex.StepDefaultsNoWaitFor[IN]`. Step transitions use
 `dex.GoTo`, or `dex.MovementOf` with `dex.GoToMulti`.
 
 Use `dex.None` when a Step, RPC, or Channel has no application payload, and pass
@@ -95,10 +95,11 @@ arbitrary values through `dex.Context`.
 ## Registration
 
 Registration uses pointer-stripped package-qualified Go types by default:
-`*orders.OrderFlow` becomes `orders.OrderFlow`. Embed `DefaultFlowType` in a
-Flow; `DefaultStepOptions` and `StepDefaults` already include
-`DefaultStepType`. Override `GetFlowType` or `GetStepType` only when an explicit
-durable identity is required.
+`*orders.OrderFlow` becomes `orders.OrderFlow`. Embed `FlowDefaults` in a
+Flow. Waiting steps embed `StepDefaults`; execute-only steps embed
+`StepDefaultsNoWaitFor[IN]`. Both include the default step type and options.
+Override `GetFlowType` or `GetStepType` only when an explicit durable identity
+is required.
 
 Registration is assembled once from each Flow's final durable type, steps,
 persistence schema, and exported RPC methods. It rejects empty or duplicate

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -28,10 +28,6 @@ type WaitForCommandStep struct {
 	dex.DefaultStepOptions
 }
 
-func (WaitForCommandStep) GetStepType() string {
-	return "wait-for-command"
-}
-
 func (WaitForCommandStep) WaitFor(
 	ctx dex.Context,
 	input OrderInput,
@@ -64,10 +60,8 @@ func (WaitForCommandStep) Execute(
 
 var WaitForCommand = WaitForCommandStep{}
 
-type OrderFlow struct{}
-
-func (OrderFlow) GetFlowType() string {
-	return "order"
+type OrderFlow struct {
+	dex.DefaultFlowType
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {
@@ -100,7 +94,13 @@ arbitrary values through `dex.Context`.
 
 ## Registration
 
-Registration is assembled once from each Flow's durable type, steps,
+Registration uses pointer-stripped package-qualified Go types by default:
+`*orders.OrderFlow` becomes `orders.OrderFlow`. Embed `DefaultFlowType` in a
+Flow; `DefaultStepOptions` and `StepDefaults` already include
+`DefaultStepType`. Override `GetFlowType` or `GetStepType` only when an explicit
+durable identity is required.
+
+Registration is assembled once from each Flow's final durable type, steps,
 persistence schema, and exported RPC methods. It rejects empty or duplicate
 names, multiple starting steps, invalid indexes, undeclared locks, and
 incompatible execute-failure targets before WorkerService starts.

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -65,20 +65,16 @@ type clientTestRPCOutput struct {
 	Status string
 }
 
-func (clientTestStep) GetStepType() string {
-	return "start"
-}
-
 func (clientTestStep) Execute(Context, clientTestInput) (StepDecision, error) {
 	return DeadEnd(), nil
 }
 
-type clientTestFlow struct{}
+type clientTestFlow struct {
+	DefaultFlowType
+}
 
-type clientNoStartFlow struct{}
-
-func (clientTestFlow) GetFlowType() string {
-	return "client-test"
+type clientNoStartFlow struct {
+	DefaultFlowType
 }
 
 func (clientTestFlow) GetSteps() []StepDef {
@@ -97,10 +93,6 @@ func (clientTestFlow) Update(
 	clientTestRPCInput,
 ) (RPCResult[clientTestRPCOutput], error) {
 	return RPCResult[clientTestRPCOutput]{Output: clientTestRPCOutput{}}, nil
-}
-
-func (clientNoStartFlow) GetFlowType() string {
-	return "client-no-start"
 }
 
 func (clientNoStartFlow) GetSteps() []StepDef {
@@ -226,8 +218,8 @@ func (service *clientTestFlowService) WaitForFlow(
 	return &dexpb.WaitForFlowResponse{
 		FlowStatus: dexpb.FlowStatus_FLOW_STATUS_COMPLETED,
 		Results: []*dexpb.StepCompletionOutput{{
-			CompletedStepType:        "start",
-			CompletedStepExecutionId: "start-1",
+			CompletedStepType:        "dex.clientTestStep",
+			CompletedStepExecutionId: "dex.clientTestStep-1",
 			CompletedStepOutput: &dexpb.Value{
 				Kind: &dexpb.Value_InternalBlobIdForStringValue{
 					InternalBlobIdForStringValue: "completion-blob",
@@ -246,7 +238,7 @@ func (service *clientTestFlowService) SearchFlows(
 		FlowRuns: []*dexpb.SearchFlowsResponseEntry{{
 			FlowId:     "order-1",
 			RunId:      "run-1",
-			FlowType:   "client-test",
+			FlowType:   "dex.clientTestFlow",
 			FlowStatus: dexpb.FlowStatus_FLOW_STATUS_RUNNING,
 			StartTime:  timestamppb.New(time.Unix(100, 0)),
 			SearchAttributes: []*dexpb.KV{{
@@ -326,7 +318,8 @@ func TestClientFlowAndPersistenceTransport(t *testing.T) {
 	require.Equal(t, "run-1", runID)
 	require.Equal(t, "business-order-1", service.startRequest.RequestId)
 	require.Equal(t, int32(0), service.startRequest.FlowTimeoutSeconds)
-	require.Equal(t, "start", service.startRequest.StartStepType)
+	require.Equal(t, "dex.clientTestFlow", service.startRequest.FlowType)
+	require.Equal(t, "dex.clientTestStep", service.startRequest.StartStepType)
 	require.Equal(t, "worker.test:8803", service.startRequest.FlowStartOptions.FlowConfigOverride.WorkerTarget.Address)
 
 	require.NoError(t, client.PublishToChannel(ctx, "order-1", clientTestCommands, "approve", "ship"))
@@ -465,10 +458,10 @@ func TestClientRPCResultsAndAdministrativeTransport(t *testing.T) {
 	require.NoError(t, client.SkipTimer(
 		ctx,
 		"order-1",
-		StepExecutionID{StepType: "start"},
+		StepExecutionID{StepType: GetFinalStepType(clientTestStep{})},
 		TimerID{ConditionID: "timeout"},
 	))
-	require.Equal(t, "start-1", service.skipTimerRequest.StepExecutionId)
+	require.Equal(t, "dex.clientTestStep-1", service.skipTimerRequest.StepExecutionId)
 
 	require.NoError(t, client.UpdateFlowConfig(ctx, "order-1", FlowConfig{
 		ContinueAsNewThreshold: ptr.Any(int32(100)),
@@ -477,7 +470,7 @@ func TestClientRPCResultsAndAdministrativeTransport(t *testing.T) {
 	require.NoError(t, client.WaitForStepCompletion(
 		ctx,
 		"order-1",
-		StepExecutionID{StepType: "start"},
+		StepExecutionID{StepType: GetFinalStepType(clientTestStep{})},
 		WaitOptions{},
 	))
 	require.Equal(t, "1", service.waitStepRequest.StepExecutionNumber)

--- a/sdk-go/dex/client_integration_test.go
+++ b/sdk-go/dex/client_integration_test.go
@@ -50,7 +50,7 @@ var (
 )
 
 type clientTestStep struct {
-	StepDefaults[clientTestInput]
+	StepDefaultsNoWaitFor[clientTestInput]
 }
 
 type clientTestInput struct {
@@ -70,11 +70,11 @@ func (clientTestStep) Execute(Context, clientTestInput) (StepDecision, error) {
 }
 
 type clientTestFlow struct {
-	DefaultFlowType
+	FlowDefaults
 }
 
 type clientNoStartFlow struct {
-	DefaultFlowType
+	FlowDefaults
 }
 
 func (clientTestFlow) GetSteps() []StepDef {

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -44,7 +44,7 @@ type stepInput struct {
 }
 
 type noPayloadStep struct {
-	dex.StepDefaults[dex.None]
+	dex.StepDefaultsNoWaitFor[dex.None]
 }
 
 func (noPayloadStep) Execute(
@@ -58,7 +58,7 @@ var noPayload = noPayloadStep{}
 var _ dex.Step[dex.None] = noPayload
 
 type waitingStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (waitingStep) WaitFor(
@@ -100,7 +100,7 @@ var waitForCommand = waitingStep{}
 var _ dex.Step[stepInput] = waitForCommand
 
 type executeOnlyStep struct {
-	dex.StepDefaults[stepInput]
+	dex.StepDefaultsNoWaitFor[stepInput]
 }
 
 func (executeOnlyStep) Execute(
@@ -116,7 +116,7 @@ var executeOnly = executeOnlyStep{}
 var _ dex.Step[stepInput] = executeOnly
 
 type contractFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (contractFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/dex/contracts_test.go
+++ b/sdk-go/dex/contracts_test.go
@@ -47,10 +47,6 @@ type noPayloadStep struct {
 	dex.StepDefaults[dex.None]
 }
 
-func (noPayloadStep) GetStepType() string {
-	return "no-payload"
-}
-
 func (noPayloadStep) Execute(
 	dex.Context,
 	dex.None,
@@ -63,10 +59,6 @@ var _ dex.Step[dex.None] = noPayload
 
 type waitingStep struct {
 	dex.DefaultStepOptions
-}
-
-func (waitingStep) GetStepType() string {
-	return "waiting"
 }
 
 func (waitingStep) WaitFor(
@@ -111,10 +103,6 @@ type executeOnlyStep struct {
 	dex.StepDefaults[stepInput]
 }
 
-func (executeOnlyStep) GetStepType() string {
-	return "execute-only"
-}
-
 func (executeOnlyStep) Execute(
 	ctx dex.Context,
 	input stepInput,
@@ -127,10 +115,8 @@ func (executeOnlyStep) Execute(
 var executeOnly = executeOnlyStep{}
 var _ dex.Step[stepInput] = executeOnly
 
-type contractFlow struct{}
-
-func (contractFlow) GetFlowType() string {
-	return "contract"
+type contractFlow struct {
+	dex.DefaultFlowType
 }
 
 func (contractFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/dex/flow.go
+++ b/sdk-go/dex/flow.go
@@ -11,17 +11,17 @@
 package dex
 
 // Flow is the top-level durable workflow definition. Any long-lived business
-// object (at least a few seconds) can be modeled as a Flow: a named type, a
-// list of Steps, and a persistence schema of attributes and channels.
+// object (at least a few seconds) can be modeled as a Flow: a Go type, a list
+// of Steps, and a persistence schema of attributes and channels.
 //
 // Exported methods on the Flow (other than the Flow interface methods) that
 // match RPC[IN, OUT] are registered as RPCs under their Go method names.
 //
 // Example:
 //
-//	type OrderFlow struct{}
-//
-//	func (OrderFlow) GetFlowType() string { return "order" }
+//	type OrderFlow struct {
+//		dex.DefaultFlowType
+//	}
 //
 //	func (OrderFlow) GetSteps() []dex.StepDef {
 //		return []dex.StepDef{
@@ -47,10 +47,8 @@ package dex
 //	var Orders = OrderFlow{}
 //	var _ dex.Flow = Orders
 type Flow interface {
-	// GetFlowType returns the durable flow type name used to start and look up
-	// runs. It must be non-empty and unique among registered flows. Prefer a
-	// stable explicit string; renaming the Go type does not change existing
-	// runs that already stored this name.
+	// GetFlowType overrides the default package-qualified Go type name.
+	// Embed DefaultFlowType to use the default.
 	GetFlowType() string
 
 	// GetSteps defines the steps of the flow. A step is one node in the flow
@@ -73,6 +71,13 @@ type Flow interface {
 	// WaitFor requests consumption and Execute reads results via
 	// Channel.GetConditionResults. Channel maps key messages by string.
 	GetPersistenceSchema() PersistenceSchema
+}
+
+// DefaultFlowType uses the package-qualified Go type as the durable flow type.
+type DefaultFlowType struct{}
+
+func (DefaultFlowType) GetFlowType() string {
+	return ""
 }
 
 // PersistenceSchema is the set of AttributeDef and ChannelDef values a Flow

--- a/sdk-go/dex/flow.go
+++ b/sdk-go/dex/flow.go
@@ -20,7 +20,7 @@ package dex
 // Example:
 //
 //	type OrderFlow struct {
-//		dex.DefaultFlowType
+//		dex.FlowDefaults
 //	}
 //
 //	func (OrderFlow) GetSteps() []dex.StepDef {
@@ -48,7 +48,7 @@ package dex
 //	var _ dex.Flow = Orders
 type Flow interface {
 	// GetFlowType overrides the default package-qualified Go type name.
-	// Embed DefaultFlowType to use the default.
+	// Embed FlowDefaults to use the default.
 	GetFlowType() string
 
 	// GetSteps defines the steps of the flow. A step is one node in the flow
@@ -73,10 +73,10 @@ type Flow interface {
 	GetPersistenceSchema() PersistenceSchema
 }
 
-// DefaultFlowType uses the package-qualified Go type as the durable flow type.
-type DefaultFlowType struct{}
+// FlowDefaults uses the package-qualified Go type as the durable flow type.
+type FlowDefaults struct{}
 
-func (DefaultFlowType) GetFlowType() string {
+func (FlowDefaults) GetFlowType() string {
 	return ""
 }
 

--- a/sdk-go/dex/proto_mapper_test.go
+++ b/sdk-go/dex/proto_mapper_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 type mapperStep struct {
-	StepDefaults[int]
+	StepDefaultsNoWaitFor[int]
 	options *StepOptions
 	name    string
 }

--- a/sdk-go/dex/registration.go
+++ b/sdk-go/dex/registration.go
@@ -13,6 +13,7 @@ package dex
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // Registry stores immutable Flow definitions shared by Client and Worker.
@@ -81,9 +82,9 @@ func (registry *Registry) registerFlow(
 	flow Flow,
 	indexTypes map[string]IndexType,
 ) (*registeredFlow, error) {
-	flowType := flow.GetFlowType()
+	flowType := GetFinalFlowType(flow)
 	if flowType == "" {
-		return nil, fmt.Errorf("dex: flow type must not be empty")
+		return nil, fmt.Errorf("dex: flow must use a named package type")
 	}
 	registered := &registeredFlow{
 		flow:       flow,
@@ -440,9 +441,9 @@ func (registry *Registry) resolveFlow(reference Flow) (*registeredFlow, error) {
 	if nilInterface(reference) {
 		return nil, fmt.Errorf("dex: flow is nil")
 	}
-	flowType := reference.GetFlowType()
+	flowType := GetFinalFlowType(reference)
 	if flowType == "" {
-		return nil, fmt.Errorf("dex: flow type must not be empty")
+		return nil, fmt.Errorf("dex: flow must use a named package type")
 	}
 	registered, found := registry.lookupFlow(flowType)
 	if !found {
@@ -457,6 +458,27 @@ func (registry *Registry) resolveFlow(reference Flow) (*registeredFlow, error) {
 		)
 	}
 	return registered, nil
+}
+
+// GetFinalFlowType returns the override or the default package-qualified Go type.
+func GetFinalFlowType(flow Flow) string {
+	if flowType := flow.GetFlowType(); flowType != "" {
+		return flowType
+	}
+	return getSimpleTypeNameFromReflect(flow)
+}
+
+// GetFinalStepType returns the override or the default package-qualified Go type.
+func GetFinalStepType[IN any](step Step[IN]) string {
+	if stepType := step.GetStepType(); stepType != "" {
+		return stepType
+	}
+	return getSimpleTypeNameFromReflect(step)
+}
+
+func getSimpleTypeNameFromReflect(value any) string {
+	valueType := reflect.TypeOf(value)
+	return strings.TrimLeft(valueType.String(), "*")
 }
 
 func (registry *Registry) resolveRPC(reference any) (*registeredFlow, *registeredRPC, error) {

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -28,6 +28,29 @@ type registrationOutput struct {
 	Value string
 }
 
+type automaticRegistrationStep struct {
+	StepDefaults[registrationInput]
+}
+
+func (automaticRegistrationStep) Execute(
+	Context,
+	registrationInput,
+) (StepDecision, error) {
+	return DeadEnd(), nil
+}
+
+type automaticRegistrationFlow struct {
+	DefaultFlowType
+}
+
+func (automaticRegistrationFlow) GetSteps() []StepDef {
+	return []StepDef{DefineStartStep(automaticRegistrationStep{})}
+}
+
+func (automaticRegistrationFlow) GetPersistenceSchema() PersistenceSchema {
+	return PersistenceSchema{}
+}
+
 type registrationStep struct {
 	stepType     string
 	options      *StepOptions
@@ -339,6 +362,21 @@ func TestRegistryRejectsNonRPCExportedMethods(t *testing.T) {
 	require.ErrorContains(t, err, "must be RPCs")
 }
 
+func TestRegistryUsesDefaultPackageQualifiedTypes(t *testing.T) {
+	flow := automaticRegistrationFlow{}
+	step := automaticRegistrationStep{}
+	require.Equal(t, "dex.automaticRegistrationFlow", GetFinalFlowType(flow))
+	require.Equal(t, GetFinalFlowType(flow), GetFinalFlowType(&flow))
+	require.Equal(t, "dex.automaticRegistrationStep", GetFinalStepType(step))
+	require.Equal(t, GetFinalStepType(step), GetFinalStepType(&step))
+
+	registry, err := NewRegistry([]Flow{&flow})
+	require.NoError(t, err)
+	registered, found := registry.lookupFlow("dex.automaticRegistrationFlow")
+	require.True(t, found)
+	require.Equal(t, "dex.automaticRegistrationStep", registered.startingStep.stepType)
+}
+
 func TestRegistryRejectsInvalidFlowsAndSteps(t *testing.T) {
 	var nilFlow *registrationFlow
 	var nilStep *registrationStep
@@ -358,11 +396,6 @@ func TestRegistryRejectsInvalidFlowsAndSteps(t *testing.T) {
 			name:  "typed nil flow",
 			flows: []Flow{nilFlow},
 			error: "flow at index 0 is nil",
-		},
-		{
-			name:  "empty flow type",
-			flows: []Flow{&registrationFlow{}},
-			error: "flow type must not be empty",
 		},
 		{
 			name: "duplicate flow type",
@@ -387,14 +420,6 @@ func TestRegistryRejectsInvalidFlowsAndSteps(t *testing.T) {
 				steps:    []StepDef{DefineStep(nilStep)},
 			}},
 			error: "step at index 0 is nil",
-		},
-		{
-			name: "empty step type",
-			flows: []Flow{&registrationFlow{
-				flowType: "flow",
-				steps:    []StepDef{DefineStep(&registrationStep{})},
-			}},
-			error: "step at index 0 has an empty type",
 		},
 		{
 			name: "duplicate step type",

--- a/sdk-go/dex/registration_test.go
+++ b/sdk-go/dex/registration_test.go
@@ -29,7 +29,7 @@ type registrationOutput struct {
 }
 
 type automaticRegistrationStep struct {
-	StepDefaults[registrationInput]
+	StepDefaultsNoWaitFor[registrationInput]
 }
 
 func (automaticRegistrationStep) Execute(
@@ -39,8 +39,19 @@ func (automaticRegistrationStep) Execute(
 	return DeadEnd(), nil
 }
 
+type stepDefaultsWithoutWaitFor struct {
+	StepDefaults
+}
+
+func (stepDefaultsWithoutWaitFor) Execute(
+	Context,
+	registrationInput,
+) (StepDecision, error) {
+	return DeadEnd(), nil
+}
+
 type automaticRegistrationFlow struct {
-	DefaultFlowType
+	FlowDefaults
 }
 
 func (automaticRegistrationFlow) GetSteps() []StepDef {
@@ -83,7 +94,7 @@ func (step *registrationStep) Execute(
 }
 
 type executeOnlyRegistrationStep struct {
-	StepDefaults[registrationInput]
+	StepDefaultsNoWaitFor[registrationInput]
 	stepType string
 }
 
@@ -99,7 +110,7 @@ func (*executeOnlyRegistrationStep) Execute(
 }
 
 type stringRegistrationStep struct {
-	StepDefaults[string]
+	StepDefaultsNoWaitFor[string]
 	stepType string
 }
 
@@ -375,6 +386,13 @@ func TestRegistryUsesDefaultPackageQualifiedTypes(t *testing.T) {
 	registered, found := registry.lookupFlow("dex.automaticRegistrationFlow")
 	require.True(t, found)
 	require.Equal(t, "dex.automaticRegistrationStep", registered.startingStep.stepType)
+}
+
+func TestStepDefaultsRequiresWaitFor(t *testing.T) {
+	_, implementsStep := any(stepDefaultsWithoutWaitFor{}).(Step[registrationInput])
+	require.False(t, implementsStep)
+	_, implementsStep = any(automaticRegistrationStep{}).(Step[registrationInput])
+	require.True(t, implementsStep)
 }
 
 func TestRegistryRejectsInvalidFlowsAndSteps(t *testing.T) {

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -23,14 +23,14 @@ type None = *none
 // Step is one node in a Flow's durable state machine. IN is the typed input
 // passed into WaitFor and Execute for this step.
 //
-// A waiting step implements WaitFor (and usually embeds DefaultStepOptions).
-// An execute-only step embeds StepDefaults[IN] (or NoWaitFor[IN]) so registration
-// sets skip_wait_for and never invokes WaitFor.
+// A waiting step embeds StepDefaults and implements WaitFor.
+// An execute-only step embeds StepDefaultsNoWaitFor[IN] (or NoWaitFor[IN]) so
+// registration sets skip_wait_for and never invokes WaitFor.
 //
 // Example (waiting step):
 //
 //	type ApproveOrderStep struct {
-//		dex.DefaultStepOptions
+//		dex.StepDefaults
 //	}
 //
 //	func (ApproveOrderStep) WaitFor(
@@ -58,7 +58,7 @@ type None = *none
 // Example (execute-only step):
 //
 //	type ShipOrderStep struct {
-//		dex.StepDefaults[ShipOrderInput]
+//		dex.StepDefaultsNoWaitFor[ShipOrderInput]
 //	}
 //
 //	func (ShipOrderStep) Execute(
@@ -75,7 +75,7 @@ type Step[IN any] interface {
 	GetStepType() string
 
 	// GetStepOptions returns immutable defaults applied whenever this step is
-	// scheduled. Return nil (e.g. by embedding DefaultStepOptions) to use server
+	// scheduled. Return nil (e.g. by embedding StepDefaults) to use server
 	// defaults. A movement may override individual fields when transitioning.
 	GetStepOptions() *StepOptions
 
@@ -89,13 +89,14 @@ type Step[IN any] interface {
 	// SetStepExecutionLocal are allowed here; writes are accepted with the
 	// WaitFor response.
 	//
-	// Optional for execute-only steps: embed NoWaitFor[IN] or StepDefaults[IN]
-	// instead of implementing a real WaitFor. Registration detects the marker and
-	// skips this method; the panic body must never run.
+	// Optional for execute-only steps: embed NoWaitFor[IN] or
+	// StepDefaultsNoWaitFor[IN] instead of implementing a real WaitFor.
+	// Registration detects the marker and skips this method; the panic body must
+	// never run.
 	WaitFor(ctx Context, input IN) (Wait, error)
 
 	// Execute decides what happens next after WaitFor conditions complete, or
-	// immediately when the step is execute-only (NoWaitFor / StepDefaults).
+	// immediately when the step is execute-only (NoWaitFor / StepDefaultsNoWaitFor).
 	//
 	//	ctx    invocation context; read condition results, timers, and
 	//	       step-execution locals set in WaitFor
@@ -136,7 +137,7 @@ type StepDef interface {
 	execute(Context, any) (StepDecision, error)
 }
 
-// NoWaitFor marks a Step as execute-only. Embed it (or StepDefaults) so
+// NoWaitFor marks a Step as execute-only. Embed it (or StepDefaultsNoWaitFor) so
 // registration sets skip_wait_for and never calls WaitFor. The WaitFor method
 // exists only to satisfy Step[IN] and panics if invoked.
 //
@@ -162,16 +163,26 @@ type DefaultStepOptions struct {
 	DefaultStepType
 }
 
-// StepDefaults embeds DefaultStepOptions and NoWaitFor for execute-only steps
-// that use server option defaults.
+// StepDefaults supplies default type and options while requiring WaitFor.
+//
+// Example:
+//
+//	type ApproveOrderStep struct {
+//		dex.StepDefaults
+//	}
+type StepDefaults struct {
+	DefaultStepOptions
+}
+
+// StepDefaultsNoWaitFor supplies defaults for execute-only steps.
 //
 // Example:
 //
 //	type ShipOrderStep struct {
-//		dex.StepDefaults[ShipOrderInput]
+//		dex.StepDefaultsNoWaitFor[ShipOrderInput]
 //	}
-type StepDefaults[IN any] struct {
-	DefaultStepOptions
+type StepDefaultsNoWaitFor[IN any] struct {
+	StepDefaults
 	NoWaitFor[IN]
 }
 

--- a/sdk-go/dex/step.go
+++ b/sdk-go/dex/step.go
@@ -33,8 +33,6 @@ type None = *none
 //		dex.DefaultStepOptions
 //	}
 //
-//	func (ApproveOrderStep) GetStepType() string { return "approve-order" }
-//
 //	func (ApproveOrderStep) WaitFor(
 //		ctx dex.Context,
 //		input ApproveOrderInput,
@@ -63,8 +61,6 @@ type None = *none
 //		dex.StepDefaults[ShipOrderInput]
 //	}
 //
-//	func (ShipOrderStep) GetStepType() string { return "ship-order" }
-//
 //	func (ShipOrderStep) Execute(
 //		ctx dex.Context,
 //		input ShipOrderInput,
@@ -74,10 +70,8 @@ type None = *none
 //
 //	var ShipOrder = ShipOrderStep{}
 type Step[IN any] interface {
-	// GetStepType returns the durable step type name used by the worker and
-	// server to select this Step for WaitFor / Execute. It must be non-empty and
-	// unique within the Flow. Prefer a stable explicit string; renaming the Go
-	// type does not change in-flight executions that already stored this name.
+	// GetStepType overrides the default package-qualified Go type name.
+	// Embed DefaultStepType to use the default.
 	GetStepType() string
 
 	// GetStepOptions returns immutable defaults applied whenever this step is
@@ -154,6 +148,9 @@ type StepDef interface {
 //	}
 type NoWaitFor[IN any] struct{}
 
+// DefaultStepType uses the package-qualified Go type as the durable step type.
+type DefaultStepType struct{}
+
 // DefaultStepOptions embeds GetStepOptions that returns nil (server defaults).
 //
 // Example:
@@ -161,7 +158,9 @@ type NoWaitFor[IN any] struct{}
 //	type ApproveOrderStep struct {
 //		dex.DefaultStepOptions
 //	}
-type DefaultStepOptions struct{}
+type DefaultStepOptions struct {
+	DefaultStepType
+}
 
 // StepDefaults embeds DefaultStepOptions and NoWaitFor for execute-only steps
 // that use server option defaults.
@@ -186,6 +185,10 @@ func (DefaultStepOptions) GetStepOptions() *StepOptions {
 	return nil
 }
 
+func (DefaultStepType) GetStepType() string {
+	return ""
+}
+
 // typedStepDef is the only concrete StepDef. Each application step is a
 // Step[IN] with its own input type, but GetSteps, registration, movements,
 // and execute-failure options need one non-generic type so differently typed
@@ -201,7 +204,7 @@ type typedStepDef[IN any] struct {
 }
 
 func (def typedStepDef[IN]) stepType() string {
-	return def.step.GetStepType()
+	return GetFinalStepType(def.step)
 }
 
 func (typedStepDef[IN]) stepInputType() reflect.Type {

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -72,10 +72,6 @@ type workerWaitingStep struct {
 	DefaultStepOptions
 }
 
-func (workerWaitingStep) GetStepType() string {
-	return "waiting"
-}
-
 func (workerWaitingStep) WaitFor(
 	ctx Context,
 	input workerTestInput,
@@ -170,10 +166,6 @@ type workerFinishStep struct {
 	StepDefaults[workerTestInput]
 }
 
-func (workerFinishStep) GetStepType() string {
-	return "finish"
-}
-
 func (workerFinishStep) Execute(
 	Context,
 	workerTestInput,
@@ -183,10 +175,8 @@ func (workerFinishStep) Execute(
 
 var workerTestFinish = workerFinishStep{}
 
-type workerTestFlow struct{}
-
-func (workerTestFlow) GetFlowType() string {
-	return "worker-test"
+type workerTestFlow struct {
+	DefaultFlowType
 }
 
 func (workerTestFlow) GetSteps() []StepDef {
@@ -235,13 +225,10 @@ func (workerTestFlow) Update(
 var workerFlow = workerTestFlow{}
 
 type workerBlockingFlow struct {
+	DefaultFlowType
 	entered     chan struct{}
 	release     chan struct{}
 	enteredOnce sync.Once
-}
-
-func (*workerBlockingFlow) GetFlowType() string {
-	return "worker-blocking"
 }
 
 func (*workerBlockingFlow) GetSteps() []StepDef {
@@ -274,8 +261,8 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 		context.Background(),
 		&dexpb.InvokeWaitForMethodRequest{
 			Context:   workerStepContext(),
-			FlowType:  workerFlow.GetFlowType(),
-			StepType:  workerTestWait.GetStepType(),
+			FlowType:  GetFinalFlowType(workerFlow),
+			StepType:  GetFinalStepType(workerTestWait),
 			StepInput: mustEncodeWorkerTestValue(t, waitInput),
 		},
 	)
@@ -291,8 +278,8 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 
 	immediateRequest := &dexpb.InvokeWaitForMethodRequest{
 		Context:  workerStepContext(),
-		FlowType: workerFlow.GetFlowType(),
-		StepType: workerTestWait.GetStepType(),
+		FlowType: GetFinalFlowType(workerFlow),
+		StepType: GetFinalStepType(workerTestWait),
 		StepInput: mustEncodeWorkerTestValue(t, workerTestInput{
 			OrderID: "order-1",
 			Mode:    "immediate",
@@ -304,8 +291,8 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 
 	comboRequest := &dexpb.InvokeWaitForMethodRequest{
 		Context:  workerStepContext(),
-		FlowType: workerFlow.GetFlowType(),
-		StepType: workerTestWait.GetStepType(),
+		FlowType: GetFinalFlowType(workerFlow),
+		StepType: GetFinalStepType(workerTestWait),
 		StepInput: mustEncodeWorkerTestValue(t, workerTestInput{
 			OrderID: "order-1",
 			Mode:    "combo",
@@ -321,7 +308,7 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, executeResponse.StepDecision.NextSteps, 1)
-	require.Equal(t, workerTestFinish.GetStepType(), executeResponse.StepDecision.NextSteps[0].StepType)
+	require.Equal(t, GetFinalStepType(workerTestFinish), executeResponse.StepDecision.NextSteps[0].StepType)
 	require.Len(t, executeResponse.UpsertAttributes, 1)
 	_, deleted := executeResponse.UpsertAttributes[0].Value.Kind.(*dexpb.Value_NullValue)
 	require.True(t, deleted)
@@ -348,7 +335,7 @@ func TestWorkerServiceDispatchesWaitExecuteAndRPC(t *testing.T) {
 		context.Background(),
 		&dexpb.InvokeWorkerRPCRequest{
 			Context:  workerRPCContext(),
-			FlowType: workerFlow.GetFlowType(),
+			FlowType: GetFinalFlowType(workerFlow),
 			RpcName:  "Update",
 			Input:    mustEncodeWorkerTestValue(t, waitInput),
 			ChannelInfos: map[string]*dexpb.ChannelInfo{
@@ -391,8 +378,8 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			name: "execute-only WaitFor",
 			call: func() error {
 				_, err := client.InvokeWaitForMethod(context.Background(), &dexpb.InvokeWaitForMethodRequest{
-					Context: workerStepContext(), FlowType: workerFlow.GetFlowType(),
-					StepType:  workerTestFinish.GetStepType(),
+					Context: workerStepContext(), FlowType: GetFinalFlowType(workerFlow),
+					StepType:  GetFinalStepType(workerTestFinish),
 					StepInput: mustEncodeWorkerTestValue(t, workerTestInput{}),
 				})
 				return err
@@ -403,7 +390,7 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			name: "unknown step",
 			call: func() error {
 				_, err := client.InvokeExecuteMethod(context.Background(), &dexpb.InvokeExecuteMethodRequest{
-					Context: workerStepContext(), FlowType: workerFlow.GetFlowType(),
+					Context: workerStepContext(), FlowType: GetFinalFlowType(workerFlow),
 					StepType: "missing", StepInput: mustEncodeWorkerTestValue(t, workerTestInput{}),
 				})
 				return err
@@ -414,7 +401,7 @@ func TestWorkerServiceMapsErrorsAndDiscardsResponses(t *testing.T) {
 			name: "unknown RPC",
 			call: func() error {
 				_, err := client.InvokeWorkerRPC(context.Background(), &dexpb.InvokeWorkerRPCRequest{
-					Context: workerRPCContext(), FlowType: workerFlow.GetFlowType(),
+					Context: workerRPCContext(), FlowType: GetFinalFlowType(workerFlow),
 					RpcName: "Missing", Input: mustEncodeWorkerTestValue(t, workerTestInput{}),
 				})
 				return err
@@ -760,7 +747,7 @@ func TestWorkerStopDrainsAndForceCancels(t *testing.T) {
 func TestWorkerTransientMovementMapping(t *testing.T) {
 	registered, err := NewRegistry([]Flow{workerFlow})
 	require.NoError(t, err)
-	flow, found := registered.lookupFlow(workerFlow.GetFlowType())
+	flow, found := registered.lookupFlow(GetFinalFlowType(workerFlow))
 	require.True(t, found)
 
 	wait := withTransientMovement(
@@ -793,7 +780,7 @@ func TestWorkerTransientMovementMapping(t *testing.T) {
 func TestWorkerRegisteredDecisionMapping(t *testing.T) {
 	registered, err := NewRegistry([]Flow{workerFlow})
 	require.NoError(t, err)
-	flow, found := registered.lookupFlow(workerFlow.GetFlowType())
+	flow, found := registered.lookupFlow(GetFinalFlowType(workerFlow))
 	require.True(t, found)
 
 	tests := []struct {
@@ -887,7 +874,7 @@ func invokeBlockingRPC(
 			context.Background(),
 			&dexpb.InvokeWorkerRPCRequest{
 				Context:  workerRPCContext(),
-				FlowType: "worker-blocking",
+				FlowType: "dex.workerBlockingFlow",
 				RpcName:  "Block",
 				Input:    input,
 			},
@@ -987,8 +974,8 @@ func workerExecuteRequest(
 ) *dexpb.InvokeExecuteMethodRequest {
 	return &dexpb.InvokeExecuteMethodRequest{
 		Context:   workerStepContext(),
-		FlowType:  workerFlow.GetFlowType(),
-		StepType:  workerTestWait.GetStepType(),
+		FlowType:  GetFinalFlowType(workerFlow),
+		StepType:  GetFinalStepType(workerTestWait),
 		StepInput: mustEncodeWorkerTestValue(t, input),
 		StepExeLocals: []*dexpb.KV{{
 			Key: "input", Value: mustEncodeWorkerTestValue(t, input),
@@ -1026,7 +1013,7 @@ func workerRPCRequest(
 ) *dexpb.InvokeWorkerRPCRequest {
 	return &dexpb.InvokeWorkerRPCRequest{
 		Context:  workerRPCContext(),
-		FlowType: workerFlow.GetFlowType(),
+		FlowType: GetFinalFlowType(workerFlow),
 		RpcName:  "Update",
 		Input:    mustEncodeWorkerTestValue(t, input),
 	}

--- a/sdk-go/dex/worker_integration_test.go
+++ b/sdk-go/dex/worker_integration_test.go
@@ -69,7 +69,7 @@ func (concreteValueHydrator) HydrateValuesInPlace(
 }
 
 type workerWaitingStep struct {
-	DefaultStepOptions
+	StepDefaults
 }
 
 func (workerWaitingStep) WaitFor(
@@ -163,7 +163,7 @@ func (workerWaitingStep) Execute(
 var workerTestWait = workerWaitingStep{}
 
 type workerFinishStep struct {
-	StepDefaults[workerTestInput]
+	StepDefaultsNoWaitFor[workerTestInput]
 }
 
 func (workerFinishStep) Execute(
@@ -176,7 +176,7 @@ func (workerFinishStep) Execute(
 var workerTestFinish = workerFinishStep{}
 
 type workerTestFlow struct {
-	DefaultFlowType
+	FlowDefaults
 }
 
 func (workerTestFlow) GetSteps() []StepDef {
@@ -225,7 +225,7 @@ func (workerTestFlow) Update(
 var workerFlow = workerTestFlow{}
 
 type workerBlockingFlow struct {
-	DefaultFlowType
+	FlowDefaults
 	entered     chan struct{}
 	release     chan struct{}
 	enteredOnce sync.Once

--- a/sdk-go/examples/order/client.go
+++ b/sdk-go/examples/order/client.go
@@ -318,7 +318,7 @@ func skipOrderTimer(
 		ctx,
 		flowID,
 		dex.StepExecutionID{
-			StepType: WaitForCommand.GetStepType(),
+			StepType: dex.GetFinalStepType(WaitForCommand),
 		},
 		dex.TimerID{ConditionID: "timeout"},
 	)
@@ -352,7 +352,7 @@ func waitForOrderStep(
 		ctx,
 		flowID,
 		dex.StepExecutionID{
-			StepType: WaitForCommand.GetStepType(),
+			StepType: dex.GetFinalStepType(WaitForCommand),
 		},
 		dex.WaitOptions{Timeout: time.Minute},
 	)

--- a/sdk-go/examples/order/main.go
+++ b/sdk-go/examples/order/main.go
@@ -46,7 +46,7 @@ type OrderSnapshot struct {
 }
 
 type WaitForCommandStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (WaitForCommandStep) WaitFor(
@@ -107,7 +107,7 @@ var WaitForCommand = WaitForCommandStep{}
 var _ dex.Step[OrderInput] = WaitForCommand
 
 type OrderFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/examples/order/main.go
+++ b/sdk-go/examples/order/main.go
@@ -49,10 +49,6 @@ type WaitForCommandStep struct {
 	dex.DefaultStepOptions
 }
 
-func (WaitForCommandStep) GetStepType() string {
-	return "wait-for-command"
-}
-
 func (WaitForCommandStep) WaitFor(
 	ctx dex.Context,
 	input OrderInput,
@@ -110,10 +106,8 @@ func (WaitForCommandStep) Execute(
 var WaitForCommand = WaitForCommandStep{}
 var _ dex.Step[OrderInput] = WaitForCommand
 
-type OrderFlow struct{}
-
-func (OrderFlow) GetFlowType() string {
-	return "order"
+type OrderFlow struct {
+	dex.DefaultFlowType
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/examples/rpc/main.go
+++ b/sdk-go/examples/rpc/main.go
@@ -21,7 +21,7 @@ type RefundOutput struct {
 }
 
 type BillingFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (BillingFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/examples/rpc/main.go
+++ b/sdk-go/examples/rpc/main.go
@@ -20,10 +20,8 @@ type RefundOutput struct {
 	Accepted bool
 }
 
-type BillingFlow struct{}
-
-func (BillingFlow) GetFlowType() string {
-	return "billing"
+type BillingFlow struct {
+	dex.DefaultFlowType
 }
 
 func (BillingFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/examples/transitions/main.go
+++ b/sdk-go/examples/transitions/main.go
@@ -35,10 +35,6 @@ type ApproveOrderStep struct {
 	dex.DefaultStepOptions
 }
 
-func (ApproveOrderStep) GetStepType() string {
-	return "approve-order"
-}
-
 func (ApproveOrderStep) WaitFor(
 	ctx dex.Context,
 	input ApproveOrderInput,
@@ -78,10 +74,6 @@ type ShipOrderStep struct {
 	dex.StepDefaults[ShipOrderInput]
 }
 
-func (ShipOrderStep) GetStepType() string {
-	return "ship-order"
-}
-
 func (ShipOrderStep) Execute(
 	ctx dex.Context,
 	input ShipOrderInput,
@@ -92,10 +84,8 @@ func (ShipOrderStep) Execute(
 var ShipOrder = ShipOrderStep{}
 var _ dex.Step[ShipOrderInput] = ShipOrder
 
-type OrderFlow struct{}
-
-func (OrderFlow) GetFlowType() string {
-	return "order-transitions"
+type OrderFlow struct {
+	dex.DefaultFlowType
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/examples/transitions/main.go
+++ b/sdk-go/examples/transitions/main.go
@@ -32,7 +32,7 @@ type ShipOrderInput struct {
 }
 
 type ApproveOrderStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (ApproveOrderStep) WaitFor(
@@ -71,7 +71,7 @@ var ApproveOrder = ApproveOrderStep{}
 var _ dex.Step[ApproveOrderInput] = ApproveOrder
 
 type ShipOrderStep struct {
-	dex.StepDefaults[ShipOrderInput]
+	dex.StepDefaultsNoWaitFor[ShipOrderInput]
 }
 
 func (ShipOrderStep) Execute(
@@ -85,7 +85,7 @@ var ShipOrder = ShipOrderStep{}
 var _ dex.Step[ShipOrderInput] = ShipOrder
 
 type OrderFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (OrderFlow) GetSteps() []dex.StepDef {

--- a/sdk-go/integ/abnormal_exit_test.go
+++ b/sdk-go/integ/abnormal_exit_test.go
@@ -23,20 +23,13 @@ type abnormalExitFlow struct {
 	emptyFlowSchema
 }
 
-func (abnormalExitFlow) GetFlowType() string {
-	return "go-sdk-abnormal-exit"
-}
-
 func (abnormalExitFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{dex.DefineStartStep(abnormalExitStep{})}
 }
 
 type abnormalExitStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[struct{}]
-}
-
-func (abnormalExitStep) GetStepType() string {
-	return "fail"
 }
 
 func (abnormalExitStep) GetStepOptions() *dex.StepOptions {

--- a/sdk-go/integ/basic_test.go
+++ b/sdk-go/integ/basic_test.go
@@ -31,7 +31,7 @@ func (basicFlow) GetSteps() []dex.StepDef {
 }
 
 type basicFirstStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (basicFirstStep) WaitFor(ctx dex.Context, input int) (dex.Wait, error) {
@@ -52,7 +52,7 @@ func (basicFirstStep) Execute(ctx dex.Context, input int) (dex.StepDecision, err
 }
 
 type basicSecondStep struct {
-	dex.StepDefaults[int]
+	dex.StepDefaultsNoWaitFor[int]
 }
 
 func (basicSecondStep) Execute(dex.Context, int) (dex.StepDecision, error) {
@@ -105,7 +105,7 @@ func (proceedOnWaitForFailureFirstStep) Execute(
 }
 
 type proceedOnWaitForFailureSecondStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (proceedOnWaitForFailureSecondStep) WaitFor(

--- a/sdk-go/integ/basic_test.go
+++ b/sdk-go/integ/basic_test.go
@@ -23,10 +23,6 @@ type basicFlow struct {
 	emptyFlowSchema
 }
 
-func (basicFlow) GetFlowType() string {
-	return "go-sdk-basic"
-}
-
 func (basicFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{
 		dex.DefineStartStep(basicFirstStep{}),
@@ -36,10 +32,6 @@ func (basicFlow) GetSteps() []dex.StepDef {
 
 type basicFirstStep struct {
 	dex.DefaultStepOptions
-}
-
-func (basicFirstStep) GetStepType() string {
-	return "first"
 }
 
 func (basicFirstStep) WaitFor(ctx dex.Context, input int) (dex.Wait, error) {
@@ -63,20 +55,12 @@ type basicSecondStep struct {
 	dex.StepDefaults[int]
 }
 
-func (basicSecondStep) GetStepType() string {
-	return "second"
-}
-
 func (basicSecondStep) Execute(dex.Context, int) (dex.StepDecision, error) {
 	return dex.GracefulComplete(3), nil
 }
 
 type proceedOnWaitForFailureFlow struct {
 	emptyFlowSchema
-}
-
-func (proceedOnWaitForFailureFlow) GetFlowType() string {
-	return "go-sdk-proceed-on-wait-for-failure"
 }
 
 func (proceedOnWaitForFailureFlow) GetSteps() []dex.StepDef {
@@ -86,10 +70,8 @@ func (proceedOnWaitForFailureFlow) GetSteps() []dex.StepDef {
 	}
 }
 
-type proceedOnWaitForFailureFirstStep struct{}
-
-func (proceedOnWaitForFailureFirstStep) GetStepType() string {
-	return "first"
+type proceedOnWaitForFailureFirstStep struct {
+	dex.DefaultStepType
 }
 
 func (proceedOnWaitForFailureFirstStep) GetStepOptions() *dex.StepOptions {
@@ -124,10 +106,6 @@ func (proceedOnWaitForFailureFirstStep) Execute(
 
 type proceedOnWaitForFailureSecondStep struct {
 	dex.DefaultStepOptions
-}
-
-func (proceedOnWaitForFailureSecondStep) GetStepType() string {
-	return "second"
 }
 
 func (proceedOnWaitForFailureSecondStep) WaitFor(

--- a/sdk-go/integ/interstate_test.go
+++ b/sdk-go/integ/interstate_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 type interStepFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (interStepFlow) GetSteps() []dex.StepDef {
@@ -43,7 +43,7 @@ func (interStepFlow) GetPersistenceSchema() dex.PersistenceSchema {
 }
 
 type interStepStartStep struct {
-	dex.StepDefaults[struct{}]
+	dex.StepDefaultsNoWaitFor[struct{}]
 }
 
 func (interStepStartStep) Execute(
@@ -57,7 +57,7 @@ func (interStepStartStep) Execute(
 }
 
 type interStepWaitStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (interStepWaitStep) WaitFor(
@@ -93,7 +93,7 @@ func (interStepWaitStep) Execute(
 }
 
 type interStepPublishStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (interStepPublishStep) WaitFor(

--- a/sdk-go/integ/interstate_test.go
+++ b/sdk-go/integ/interstate_test.go
@@ -23,10 +23,8 @@ var (
 	interStepSecondChannel = dex.DefineChannel[int]("inter-step-second")
 )
 
-type interStepFlow struct{}
-
-func (interStepFlow) GetFlowType() string {
-	return "go-sdk-inter-step"
+type interStepFlow struct {
+	dex.DefaultFlowType
 }
 
 func (interStepFlow) GetSteps() []dex.StepDef {
@@ -48,10 +46,6 @@ type interStepStartStep struct {
 	dex.StepDefaults[struct{}]
 }
 
-func (interStepStartStep) GetStepType() string {
-	return "start"
-}
-
 func (interStepStartStep) Execute(
 	dex.Context,
 	struct{},
@@ -64,10 +58,6 @@ func (interStepStartStep) Execute(
 
 type interStepWaitStep struct {
 	dex.DefaultStepOptions
-}
-
-func (interStepWaitStep) GetStepType() string {
-	return "wait"
 }
 
 func (interStepWaitStep) WaitFor(
@@ -104,10 +94,6 @@ func (interStepWaitStep) Execute(
 
 type interStepPublishStep struct {
 	dex.DefaultStepOptions
-}
-
-func (interStepPublishStep) GetStepType() string {
-	return "publish"
 }
 
 func (interStepPublishStep) WaitFor(

--- a/sdk-go/integ/main_test.go
+++ b/sdk-go/integ/main_test.go
@@ -27,7 +27,9 @@ import (
 
 var integClient *dex.Client
 
-type emptyFlowSchema struct{}
+type emptyFlowSchema struct {
+	dex.DefaultFlowType
+}
 
 func (emptyFlowSchema) GetPersistenceSchema() dex.PersistenceSchema {
 	return dex.PersistenceSchema{}

--- a/sdk-go/integ/main_test.go
+++ b/sdk-go/integ/main_test.go
@@ -28,7 +28,7 @@ import (
 var integClient *dex.Client
 
 type emptyFlowSchema struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (emptyFlowSchema) GetPersistenceSchema() dex.PersistenceSchema {

--- a/sdk-go/integ/no_startstate_test.go
+++ b/sdk-go/integ/no_startstate_test.go
@@ -36,7 +36,7 @@ func (noStartStepFlow) Start(
 }
 
 type noStartFinishStep struct {
-	dex.StepDefaults[int]
+	dex.StepDefaultsNoWaitFor[int]
 }
 
 func (noStartFinishStep) Execute(

--- a/sdk-go/integ/no_startstate_test.go
+++ b/sdk-go/integ/no_startstate_test.go
@@ -21,10 +21,6 @@ type noStartStepFlow struct {
 	emptyFlowSchema
 }
 
-func (noStartStepFlow) GetFlowType() string {
-	return "go-sdk-no-start-step"
-}
-
 func (noStartStepFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{dex.DefineStep(noStartFinishStep{})}
 }
@@ -41,10 +37,6 @@ func (noStartStepFlow) Start(
 
 type noStartFinishStep struct {
 	dex.StepDefaults[int]
-}
-
-func (noStartFinishStep) GetStepType() string {
-	return "finish"
 }
 
 func (noStartFinishStep) Execute(

--- a/sdk-go/integ/no_state_test.go
+++ b/sdk-go/integ/no_state_test.go
@@ -24,10 +24,6 @@ type noStepFlow struct {
 	emptyFlowSchema
 }
 
-func (noStepFlow) GetFlowType() string {
-	return "go-sdk-no-step"
-}
-
 func (noStepFlow) GetSteps() []dex.StepDef {
 	return nil
 }
@@ -55,7 +51,7 @@ func TestFlowWithoutSteps(t *testing.T) {
 	require.Eventually(t, func() bool {
 		searchPage, err = integClient.SearchFlows(
 			ctx,
-			"FlowType = '"+flow.GetFlowType()+"'",
+			"FlowType = '"+dex.GetFinalFlowType(flow)+"'",
 			100,
 			"",
 		)

--- a/sdk-go/integ/persistence_test.go
+++ b/sdk-go/integ/persistence_test.go
@@ -65,7 +65,7 @@ type persistenceModel struct {
 }
 
 type persistenceFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (persistenceFlow) GetSteps() []dex.StepDef {
@@ -90,7 +90,7 @@ func (persistenceFlow) GetPersistenceSchema() dex.PersistenceSchema {
 }
 
 type persistenceFirstStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (persistenceFirstStep) WaitFor(
@@ -168,7 +168,7 @@ func (persistenceFirstStep) Execute(
 }
 
 type persistenceSecondStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (persistenceSecondStep) WaitFor(

--- a/sdk-go/integ/persistence_test.go
+++ b/sdk-go/integ/persistence_test.go
@@ -64,10 +64,8 @@ type persistenceModel struct {
 	Datetime time.Time
 }
 
-type persistenceFlow struct{}
-
-func (persistenceFlow) GetFlowType() string {
-	return "go-sdk-persistence"
+type persistenceFlow struct {
+	dex.DefaultFlowType
 }
 
 func (persistenceFlow) GetSteps() []dex.StepDef {
@@ -93,10 +91,6 @@ func (persistenceFlow) GetPersistenceSchema() dex.PersistenceSchema {
 
 type persistenceFirstStep struct {
 	dex.DefaultStepOptions
-}
-
-func (persistenceFirstStep) GetStepType() string {
-	return "first"
 }
 
 func (persistenceFirstStep) WaitFor(
@@ -175,10 +169,6 @@ func (persistenceFirstStep) Execute(
 
 type persistenceSecondStep struct {
 	dex.DefaultStepOptions
-}
-
-func (persistenceSecondStep) GetStepType() string {
-	return "second"
 }
 
 func (persistenceSecondStep) WaitFor(
@@ -308,7 +298,7 @@ func TestPersistenceFlow(t *testing.T) {
 			return false
 		}
 		for _, entry := range searchPage.Flows {
-			if entry.FlowID == flowID && entry.FlowType == (persistenceFlow{}).GetFlowType() {
+			if entry.FlowID == flowID && entry.FlowType == dex.GetFinalFlowType(persistenceFlow{}) {
 				return true
 			}
 		}

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -24,10 +24,8 @@ var (
 	rpcFlowStatus  = dex.DefineAttribute[string]("rpc-status")
 )
 
-type rpcFlow struct{}
-
-func (rpcFlow) GetFlowType() string {
-	return "go-sdk-rpc"
+type rpcFlow struct {
+	dex.DefaultFlowType
 }
 
 func (rpcFlow) GetSteps() []dex.StepDef {
@@ -80,10 +78,6 @@ func (rpcFlow) Fail(
 
 type rpcFlowStep struct {
 	dex.DefaultStepOptions
-}
-
-func (rpcFlowStep) GetStepType() string {
-	return "wait-for-rpc"
 }
 
 func (rpcFlowStep) WaitFor(

--- a/sdk-go/integ/rpc_test.go
+++ b/sdk-go/integ/rpc_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 type rpcFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (rpcFlow) GetSteps() []dex.StepDef {
@@ -77,7 +77,7 @@ func (rpcFlow) Fail(
 }
 
 type rpcFlowStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (rpcFlowStep) WaitFor(

--- a/sdk-go/integ/signal_test.go
+++ b/sdk-go/integ/signal_test.go
@@ -25,10 +25,8 @@ var (
 	channelFlowSecond = dex.DefineChannel[int]("second")
 )
 
-type channelFlow struct{}
-
-func (channelFlow) GetFlowType() string {
-	return "go-sdk-channel"
+type channelFlow struct {
+	dex.DefaultFlowType
 }
 
 func (channelFlow) GetSteps() []dex.StepDef {
@@ -47,10 +45,6 @@ func (channelFlow) GetPersistenceSchema() dex.PersistenceSchema {
 
 type channelFlowFirstStep struct {
 	dex.DefaultStepOptions
-}
-
-func (channelFlowFirstStep) GetStepType() string {
-	return "first"
 }
 
 func (channelFlowFirstStep) WaitFor(
@@ -87,10 +81,6 @@ func (channelFlowFirstStep) Execute(
 
 type channelFlowSecondStep struct {
 	dex.DefaultStepOptions
-}
-
-func (channelFlowSecondStep) GetStepType() string {
-	return "second"
 }
 
 func (channelFlowSecondStep) WaitFor(
@@ -163,7 +153,7 @@ func runChannelFlow(
 	require.NoError(t, integClient.WaitForStepCompletion(
 		ctx,
 		flowID,
-		dex.StepExecutionID{StepType: "first"},
+		dex.StepExecutionID{StepType: dex.GetFinalStepType(channelFlowFirstStep{})},
 		dex.WaitOptions{Timeout: 20 * time.Second},
 	))
 	require.NoError(t, integClient.PublishToChannel(
@@ -176,7 +166,7 @@ func runChannelFlow(
 		err = integClient.SkipTimer(
 			ctx,
 			flowID,
-			dex.StepExecutionID{StepType: "second"},
+			dex.StepExecutionID{StepType: dex.GetFinalStepType(channelFlowSecondStep{})},
 			dex.TimerID{Index: ptr.Any(int32(0))},
 		)
 		return err == nil

--- a/sdk-go/integ/signal_test.go
+++ b/sdk-go/integ/signal_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 type channelFlow struct {
-	dex.DefaultFlowType
+	dex.FlowDefaults
 }
 
 func (channelFlow) GetSteps() []dex.StepDef {
@@ -44,7 +44,7 @@ func (channelFlow) GetPersistenceSchema() dex.PersistenceSchema {
 }
 
 type channelFlowFirstStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (channelFlowFirstStep) WaitFor(
@@ -80,7 +80,7 @@ func (channelFlowFirstStep) Execute(
 }
 
 type channelFlowSecondStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (channelFlowSecondStep) WaitFor(

--- a/sdk-go/integ/skip_wait_until_test.go
+++ b/sdk-go/integ/skip_wait_until_test.go
@@ -21,10 +21,6 @@ type executeOnlyFlow struct {
 	emptyFlowSchema
 }
 
-func (executeOnlyFlow) GetFlowType() string {
-	return "go-sdk-execute-only"
-}
-
 func (executeOnlyFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{
 		dex.DefineStartStep(executeOnlyFirstStep{}),
@@ -34,10 +30,6 @@ func (executeOnlyFlow) GetSteps() []dex.StepDef {
 
 type executeOnlyValueFlow struct {
 	emptyFlowSchema
-}
-
-func (executeOnlyValueFlow) GetFlowType() string {
-	return "go-sdk-execute-only-value-flow"
 }
 
 func (executeOnlyValueFlow) GetSteps() []dex.StepDef {
@@ -51,10 +43,6 @@ type executeOnlyFirstStep struct {
 	dex.StepDefaults[int]
 }
 
-func (executeOnlyFirstStep) GetStepType() string {
-	return "first"
-}
-
 func (executeOnlyFirstStep) Execute(
 	_ dex.Context,
 	input int,
@@ -64,10 +52,6 @@ func (executeOnlyFirstStep) Execute(
 
 type executeOnlySecondStep struct {
 	dex.StepDefaults[int]
-}
-
-func (executeOnlySecondStep) GetStepType() string {
-	return "second"
 }
 
 func (executeOnlySecondStep) Execute(

--- a/sdk-go/integ/skip_wait_until_test.go
+++ b/sdk-go/integ/skip_wait_until_test.go
@@ -40,7 +40,7 @@ func (executeOnlyValueFlow) GetSteps() []dex.StepDef {
 }
 
 type executeOnlyFirstStep struct {
-	dex.StepDefaults[int]
+	dex.StepDefaultsNoWaitFor[int]
 }
 
 func (executeOnlyFirstStep) Execute(
@@ -51,7 +51,7 @@ func (executeOnlyFirstStep) Execute(
 }
 
 type executeOnlySecondStep struct {
-	dex.StepDefaults[int]
+	dex.StepDefaultsNoWaitFor[int]
 }
 
 func (executeOnlySecondStep) Execute(

--- a/sdk-go/integ/state_recovery_test.go
+++ b/sdk-go/integ/state_recovery_test.go
@@ -46,7 +46,7 @@ func (executeRecoveryFailStep) Execute(dex.Context, string) (dex.StepDecision, e
 }
 
 type executeRecoveryFinishStep struct {
-	dex.StepDefaults[string]
+	dex.StepDefaultsNoWaitFor[string]
 }
 
 func (executeRecoveryFinishStep) Execute(

--- a/sdk-go/integ/state_recovery_test.go
+++ b/sdk-go/integ/state_recovery_test.go
@@ -22,10 +22,6 @@ type executeRecoveryFlow struct {
 	emptyFlowSchema
 }
 
-func (executeRecoveryFlow) GetFlowType() string {
-	return "go-sdk-execute-recovery"
-}
-
 func (executeRecoveryFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{
 		dex.DefineStartStep(executeRecoveryFailStep{}),
@@ -34,11 +30,8 @@ func (executeRecoveryFlow) GetSteps() []dex.StepDef {
 }
 
 type executeRecoveryFailStep struct {
+	dex.DefaultStepType
 	dex.NoWaitFor[string]
-}
-
-func (executeRecoveryFailStep) GetStepType() string {
-	return "fail"
 }
 
 func (executeRecoveryFailStep) GetStepOptions() *dex.StepOptions {
@@ -54,10 +47,6 @@ func (executeRecoveryFailStep) Execute(dex.Context, string) (dex.StepDecision, e
 
 type executeRecoveryFinishStep struct {
 	dex.StepDefaults[string]
-}
-
-func (executeRecoveryFinishStep) GetStepType() string {
-	return "finish"
 }
 
 func (executeRecoveryFinishStep) Execute(

--- a/sdk-go/integ/timer_test.go
+++ b/sdk-go/integ/timer_test.go
@@ -23,20 +23,12 @@ type timerFlow struct {
 	emptyFlowSchema
 }
 
-func (timerFlow) GetFlowType() string {
-	return "go-sdk-timer"
-}
-
 func (timerFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{dex.DefineStartStep(timerStep{})}
 }
 
 type timerStep struct {
 	dex.DefaultStepOptions
-}
-
-func (timerStep) GetStepType() string {
-	return "timer"
 }
 
 func (timerStep) WaitFor(

--- a/sdk-go/integ/timer_test.go
+++ b/sdk-go/integ/timer_test.go
@@ -28,7 +28,7 @@ func (timerFlow) GetSteps() []dex.StepDef {
 }
 
 type timerStep struct {
-	dex.DefaultStepOptions
+	dex.StepDefaults
 }
 
 func (timerStep) WaitFor(

--- a/sdk-go/integ/workflow_uncompleted_test.go
+++ b/sdk-go/integ/workflow_uncompleted_test.go
@@ -29,7 +29,7 @@ func (forceFailFlow) GetSteps() []dex.StepDef {
 }
 
 type forceFailStep struct {
-	dex.StepDefaults[struct{}]
+	dex.StepDefaultsNoWaitFor[struct{}]
 }
 
 func (forceFailStep) Execute(

--- a/sdk-go/integ/workflow_uncompleted_test.go
+++ b/sdk-go/integ/workflow_uncompleted_test.go
@@ -24,20 +24,12 @@ type forceFailFlow struct {
 	emptyFlowSchema
 }
 
-func (forceFailFlow) GetFlowType() string {
-	return "go-sdk-force-fail"
-}
-
 func (forceFailFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{dex.DefineStartStep(forceFailStep{})}
 }
 
 type forceFailStep struct {
 	dex.StepDefaults[struct{}]
-}
-
-func (forceFailStep) GetStepType() string {
-	return "fail"
 }
 
 func (forceFailStep) Execute(
@@ -51,18 +43,12 @@ type waitForFailureFlow struct {
 	emptyFlowSchema
 }
 
-func (waitForFailureFlow) GetFlowType() string {
-	return "go-sdk-wait-for-failure"
-}
-
 func (waitForFailureFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{dex.DefineStartStep(waitForFailureStep{})}
 }
 
-type waitForFailureStep struct{}
-
-func (waitForFailureStep) GetStepType() string {
-	return "fail"
+type waitForFailureStep struct {
+	dex.DefaultStepType
 }
 
 func (waitForFailureStep) GetStepOptions() *dex.StepOptions {
@@ -87,18 +73,12 @@ type waitForTimeoutFlow struct {
 	emptyFlowSchema
 }
 
-func (waitForTimeoutFlow) GetFlowType() string {
-	return "go-sdk-wait-for-timeout"
-}
-
 func (waitForTimeoutFlow) GetSteps() []dex.StepDef {
 	return []dex.StepDef{dex.DefineStartStep(waitForTimeoutStep{})}
 }
 
-type waitForTimeoutStep struct{}
-
-func (waitForTimeoutStep) GetStepType() string {
-	return "timeout"
+type waitForTimeoutStep struct {
+	dex.DefaultStepType
 }
 
 func (waitForTimeoutStep) GetStepOptions() *dex.StepOptions {


### PR DESCRIPTION
## Summary

- keep `GetFlowType` and `GetStepType` as optional durable-name overrides
- add `DefaultFlowType` and `DefaultStepType` implementations that select pointer-stripped Go type names
- use the same final-name resolver across registration, movements, Client requests, and Worker dispatch
- migrate SDK examples, integration flows, and existing Go examples to the defaults

## Rationale

Most applications should not repeat durable type strings for every Flow and Step. The default now follows the iWF convention and derives names such as `orders.OrderFlow` from `reflect.TypeOf(value).String()`, while preserving explicit non-empty overrides.

## User impact

Flows embed `dex.DefaultFlowType`. Waiting steps already get the default through `dex.DefaultStepOptions`, and execute-only steps through `dex.StepDefaults[IN]`. Applications can call `dex.GetFinalFlowType` and `dex.GetFinalStepType` when they need the resolved durable identity.

## Validation

- `make -C sdk-go unitTests`
- `make -C sdk-go clientIntegTests`
- `make -C sdk-go workerIntegTests`
- `make -C sdk-go e2eTests`
- `make -C examples/go unitTests`
- `make copyright-check`
